### PR TITLE
docs: vs-code settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note that the JSX template doesn't provide completion for attribute value by def
 editor.quickSuggestions": {
     "other": true,
     "comments": false,
-    "strings": false
+    "strings": true
 },
 ```
 


### PR DESCRIPTION
The previous one was the default settings mentioned in [vs code docs](https://code.visualstudio.com/docs/editor/intellisense#_customizing-intellisense). You need to set `"strings": true` to work.