### PR TITLE
Add Astro to default `activeHTMLFileExtensions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 						"tsx",
 						"vue",
 						"twig",
+						"astro",
 						"svelte"
 					],
 					"items": {


### PR DESCRIPTION
https://astro.build/

I'm shocked this is not already the case 😄 