### PR TITLE
Fix issue #136 by updating the language server stack

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,0 +1,56 @@
+name: Test suite
+
+on:
+  push:
+    branches:
+      - master
+      - feature/*
+      - release/*
+  pull_request:
+    branches:
+      - master
+      - feature/*
+      - release/*
+
+jobs:
+  # Fast checks: lint, type-check/build and the parser unit tests.
+  lint-build-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Unit tests
+        run: npm test
+
+  # End-to-end tests across every OS, against the oldest supported and the latest VSCode.
+  e2e:
+    needs: lint-build-unit
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        vscode: ['1.91.0', 'stable']
+    runs-on: ${{ matrix.os }}
+    env:
+      VSCODE_VERSION: ${{ matrix.vscode }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install
+      - name: Build
+        run: npm run build
+      - name: E2E tests (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run e2e-test
+      - name: E2E tests (macOS / Windows)
+        if: runner.os != 'Linux'
+        run: npm run e2e-test

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -6,11 +6,13 @@ on:
       - master
       - feature/*
       - release/*
+      - fix/*
   pull_request:
     branches:
       - master
       - feature/*
       - release/*
+      - fix/*
 
 jobs:
   # Fast checks: lint, type-check/build and the parser unit tests.

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 node_modules
+!client/test/fixture/node_modules/
+!client/test/fixture/node_modules/**
 out
 .vscode-test
 **/*.tsbuildinfo
 **/package-lock.json
 *.vsix
 .VSCodeCounter
-

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,8 +9,6 @@
 **/*.tsbuildInfo
 **/package-lock.json
 .travis.yml
-client/node_modules/!(vscode-*)/**
-client/node_modules/vscode-test
 client/test/**
 images/!(logo.png)
 .VSCodeCounter/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # ChangeLog
 
 
+## [2.14.0]
+
+- Upgrade `vscode-languageclient` / `vscode-languageserver` to `^10` (and `vscode-uri` to `^3`). This fixes `Couldn't start client CSS Navigation`, which was caused by the old `vscode-languageclient@4` / `vscode-languageserver@6` stack being incompatible with the newer `vscode-languageserver-protocol@3.18` / `vscode-jsonrpc@9` that a fresh install resolves to.
+- Raise the minimum VSCode engine to `^1.91.0` (required by `vscode-languageclient@10`).
+- Replace the deprecated `vscode` package with `@types/vscode`, and switch the e2e tests to `@vscode/test-electron` + `mocha`.
+
+
 ## [2.13.1]
 
 - Fix `maxFileCount` not fully work issue.

--- a/client/package.json
+++ b/client/package.json
@@ -2,13 +2,9 @@
 	"name": "vscode-css-navigation-client",
 	"description": "Client Part",
 	"engines": {
-		"vscode": "^1.96.1"
-	},
-	"scripts": {
-		"update-vscode": "vscode-install",
-		"postinstall": "vscode-install"
+		"vscode": "^1.91.0"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^4.4.2"
+		"vscode-languageclient": "^10.0.0"
 	}
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,6 +4,18 @@ import {LanguageClient, LanguageClientOptions, ServerOptions, TransportKind} fro
 import {getOutmostWorkspaceURI, getPathExtension, generateGlobPatternFromExtensions, getTimeMarker, fetchAsText} from './utils'
 
 
+/** Wire shape of the `definitions` / `references` server responses. */
+interface LocationsResponse {
+	data: {
+		uri: string
+		range: {
+			start: {line: number, character: number}
+			end: {line: number, character: number}
+		}
+	}[] | null
+}
+
+
 process.on('unhandledRejection', function(reason) {
 	console.log('Unhandled Rejection: ', reason)
 })
@@ -16,17 +28,17 @@ export function activate(context: vscode.ExtensionContext): CSSNavigationExtensi
 	extension = new CSSNavigationExtension(context)
 
 	// Register command.
-	let moveCursorForwardCommand = vscode.commands.registerCommand(
+	const moveCursorForwardCommand = vscode.commands.registerCommand(
 		'CSSNavigation.moveCursorForward',
 		() => {
-			let editor = vscode.window.activeTextEditor
+			const editor = vscode.window.activeTextEditor
 			if (!editor) {
 				return
 			}
 
-			let currentPosition = editor.selection.active
+			const currentPosition = editor.selection.active
 
-			let newPosition = currentPosition.with(
+			const newPosition = currentPosition.with(
 				currentPosition.line,
 				Math.max(0, currentPosition.character - 1)
 			)
@@ -39,25 +51,25 @@ export function activate(context: vscode.ExtensionContext): CSSNavigationExtensi
 
 
 	// Register command.
-	let peekDefinitionsCommand = vscode.commands.registerCommand(
+	const peekDefinitionsCommand = vscode.commands.registerCommand(
 		'CSSNavigation.peekDefinitions',
 		async (uri: string, position: vscode.Position) => {
-			let theURI = vscode.Uri.parse(uri)
-			let client = extension.ensureClientForOpenedURI(theURI)
+			const theURI = vscode.Uri.parse(uri)
+			const client = extension.ensureClientForOpenedURI(theURI)
 
 			if (!client) {
 				return
 			}
 
-			let tokenSource = new vscode.CancellationTokenSource()
+			const tokenSource = new vscode.CancellationTokenSource()
 
-			let result = await client.sendRequest(
-				'definitions', 
+			const result = await client.sendRequest<LocationsResponse>(
+				'definitions',
 				{uri, position},
 				tokenSource.token
-			) as {data: vscode.Location[] | null}
+			)
 			
-			let definitions = result.data as vscode.Location[] | null
+			const definitions = result.data
 			if (definitions && definitions.length > 0) {
 				await vscode.commands.executeCommand(
 					'editor.action.peekLocations',
@@ -78,25 +90,25 @@ export function activate(context: vscode.ExtensionContext): CSSNavigationExtensi
 		}
 	)
 
-	let peekReferencesCommand = vscode.commands.registerCommand(
+	const peekReferencesCommand = vscode.commands.registerCommand(
 		'CSSNavigation.peekReferences',
 		async (uri: string, position: vscode.Position) => {
-			let theURI = vscode.Uri.parse(uri)
-			let client = extension.ensureClientForOpenedURI(theURI)
+			const theURI = vscode.Uri.parse(uri)
+			const client = extension.ensureClientForOpenedURI(theURI)
 
 			if (!client) {
 				return
 			}
 
-			let tokenSource = new vscode.CancellationTokenSource()
+			const tokenSource = new vscode.CancellationTokenSource()
 
-			let result = await client.sendRequest(
-				'references', 
+			const result = await client.sendRequest<LocationsResponse>(
+				'references',
 				{uri, position},
 				tokenSource.token
-			) as {data: vscode.Location[] | null}
+			)
 
-			let references = result.data as vscode.Location[] | null
+			const references = result.data
 			if (references && references.length > 0) {
 				await vscode.commands.executeCommand(
 					'editor.action.peekLocations',
@@ -123,7 +135,7 @@ export function activate(context: vscode.ExtensionContext): CSSNavigationExtensi
 	// Register a content provider to open remote URI.
 	const httpProvider = new class implements vscode.TextDocumentContentProvider {
 		provideTextDocumentContent(myURI: vscode.Uri): Promise<string> {
-			let uri = myURI.path
+			const uri = myURI.path
 			return fetchAsText(uri)
 		}
 	}
@@ -136,7 +148,7 @@ export function activate(context: vscode.ExtensionContext): CSSNavigationExtensi
 		vscode.workspace.onDidChangeConfiguration((event) => {
 			if (event.affectsConfiguration('CSSNavigation')) {
 				extension.loadConfig()
-				extension.restartAllClients()
+				void extension.restartAllClients()
 			}
 		}),
 
@@ -145,8 +157,8 @@ export function activate(context: vscode.ExtensionContext): CSSNavigationExtensi
 		}),
 
 		vscode.workspace.onDidChangeWorkspaceFolders(event => {
-			for (let folder of event.removed) {
-				extension.stopClient(folder)
+			for (const folder of event.removed) {
+				void extension.stopClient(folder)
 			}
 
 			// Even only removes a folder, we may still need to restart all servers for every folder,
@@ -187,7 +199,7 @@ export class CSSNavigationExtension {
 
 	/** Get configuration object. */
 	private getConfigObject(): Configuration {
-		let config = this.config
+		const config = this.config
 
 		return {
 			enableGoToDefinition: config.get('enableGoToDefinition', true),
@@ -222,15 +234,15 @@ export class CSSNavigationExtension {
 
 	/** Sync server with workspace folders. */
 	ensureClients() {
-		let searchAcrossWorkspaceFolders: boolean = this.config.get('searchAcrossWorkspaceFolders', false)
+		const searchAcrossWorkspaceFolders: boolean = this.config.get('searchAcrossWorkspaceFolders', false)
 
 		if (searchAcrossWorkspaceFolders) {
-			for (let workspaceFolder of vscode.workspace.workspaceFolders || []) {
+			for (const workspaceFolder of vscode.workspace.workspaceFolders || []) {
 				this.ensureClientForWorkspace(workspaceFolder)
 			}
 		}
 		else {
-			for (let document of vscode.workspace.textDocuments) {
+			for (const document of vscode.workspace.textDocuments) {
 				this.ensureClientForOpenedURI(document.uri)
 			}
 		}
@@ -238,19 +250,19 @@ export class CSSNavigationExtension {
 
 	/** Make sure client to be started for workspace folder. */
 	private ensureClientForWorkspace(workspaceFolder: vscode.WorkspaceFolder): LanguageClient | null {
-		let workspaceURI = workspaceFolder.uri.toString()
-		let workspaceURIs = (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.toString())
-		let outmostWorkspaceURI = getOutmostWorkspaceURI(workspaceURI, workspaceURIs)
+		const workspaceURI = workspaceFolder.uri.toString()
+		const workspaceURIs = (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.toString())
+		const outmostWorkspaceURI = getOutmostWorkspaceURI(workspaceURI, workspaceURIs)
 
 		//was covered by another folder, stop it
 		if (outmostWorkspaceURI && workspaceURI !== outmostWorkspaceURI && this.clients.has(workspaceURI)) {
-			this.stopClient(workspaceFolder)
+			void this.stopClient(workspaceFolder)
 		}
 		
 		if (outmostWorkspaceURI && !this.clients.has(outmostWorkspaceURI)) {
-			let workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(outmostWorkspaceURI))
+			const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(outmostWorkspaceURI))
 			if (workspaceFolder) {
-				this.startClientFor(workspaceFolder)
+				void this.startClientFor(workspaceFolder)
 			}
 		}
 
@@ -268,16 +280,16 @@ export class CSSNavigationExtension {
 			return null
 		}
 
-		let activeHTMLFileExtensions: string[] = this.config.get('activeHTMLFileExtensions', [])
-		let activeCSSFileExtensions: string[] = this.config.get('activeCSSFileExtensions', [])
-		let extension = getPathExtension(uri.fsPath)
+		const activeHTMLFileExtensions: string[] = this.config.get('activeHTMLFileExtensions', [])
+		const activeCSSFileExtensions: string[] = this.config.get('activeCSSFileExtensions', [])
+		const extension = getPathExtension(uri.fsPath)
 		
 		if (!activeHTMLFileExtensions.includes(extension) && !activeCSSFileExtensions.includes(extension)) {
 			return null
 		}
 
 		// Not in any workspace.
-		let workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
+		const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)
 		if (!workspaceFolder) {
 			return null
 		}
@@ -287,28 +299,28 @@ export class CSSNavigationExtension {
 
 	/** Start client & server for workspace folder. */
 	private async startClientFor(workspaceFolder: vscode.WorkspaceFolder) {
-		let workspaceFolderPath = workspaceFolder.uri.fsPath
-		let activeHTMLFileExtensions: string[] = this.config.get('activeHTMLFileExtensions', [])
-		let activeCSSFileExtensions: string[] = this.config.get('activeCSSFileExtensions', [])
-		let searchAcrossWorkspaceFolders: boolean = this.config.get('searchAcrossWorkspaceFolders', false)
+		const workspaceFolderPath = workspaceFolder.uri.fsPath
+		const activeHTMLFileExtensions: string[] = this.config.get('activeHTMLFileExtensions', [])
+		const activeCSSFileExtensions: string[] = this.config.get('activeCSSFileExtensions', [])
+		const searchAcrossWorkspaceFolders: boolean = this.config.get('searchAcrossWorkspaceFolders', false)
 
-		let serverModule = this.context.asAbsolutePath(
+		const serverModule = this.context.asAbsolutePath(
 			path.join('server', 'out', 'server.js')
 		)
 		
 		// One port for only one server to debug should be ok.
-		let debugOptions = {execArgv: ["--nolazy", '--inspect=6009']}
+		const debugOptions = {execArgv: ["--nolazy", '--inspect=6009']}
 
-		let serverOptions: ServerOptions = {
+		const serverOptions: ServerOptions = {
 			run: {module: serverModule, transport: TransportKind.ipc},
 			debug: {module: serverModule, transport: TransportKind.ipc, options: debugOptions},
 		}
 
 		// To notify open / close / content changed for html & css files in specified range, and provide language service.
-		let htmlCSSPattern = generateGlobPatternFromExtensions([...activeHTMLFileExtensions, ...activeCSSFileExtensions])
-		let configuration = this.getConfigObject()
+		const htmlCSSPattern = generateGlobPatternFromExtensions([...activeHTMLFileExtensions, ...activeCSSFileExtensions])
+		const configuration = this.getConfigObject()
 
-		let clientOptions: LanguageClientOptions = {
+		const clientOptions: LanguageClientOptions = {
 			documentSelector: [{
 				scheme: 'file',
 				//language: 'plaintext', //plaintext is not work, just ignore it if match all plaintext files
@@ -328,13 +340,13 @@ export class CSSNavigationExtension {
 				fileEvents: vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(workspaceFolderPath, `**`))
 			},
 
-			initializationOptions: <InitializationOptions>{
+			initializationOptions: {
 				workspaceFolderPath,
 				configuration,
 			},
 		}
 
-		let client = new LanguageClient('css-navigation', 'CSS Navigation', serverOptions, clientOptions)
+		const client = new LanguageClient('css-navigation', 'CSS Navigation', serverOptions, clientOptions)
 
 		// Register before awaiting `start()`, so re-entrant `ensureClient*` calls reuse this client.
 		this.clients.set(workspaceFolder.uri.toString(), client)
@@ -353,7 +365,7 @@ export class CSSNavigationExtension {
 			await client.start()
 		}
 		catch (err) {
-			this.showChannelMessage(getTimeMarker() + `❌ Client for workspace "${workspaceFolder.name}" failed to start: ${err}`)
+			this.showChannelMessage(getTimeMarker() + `❌ Client for workspace "${workspaceFolder.name}" failed to start: ${String(err)}`)
 		}
 	}
 
@@ -366,8 +378,8 @@ export class CSSNavigationExtension {
 	async stopClient(workspaceFolder: vscode.WorkspaceFolder) {
 		this.unwatchLastWatchedGitIgnoreFile(workspaceFolder)
 
-		let uri = workspaceFolder.uri.toString()
-		let client = this.clients.get(uri)
+		const uri = workspaceFolder.uri.toString()
+		const client = this.clients.get(uri)
 		if (client) {
 			this.clients.delete(uri)
 
@@ -379,7 +391,7 @@ export class CSSNavigationExtension {
 				}
 			}
 			catch (err) {
-				this.showChannelMessage(getTimeMarker() + `Error while stopping client for workspace folder "${workspaceFolder.name}": ${err}`)
+				this.showChannelMessage(getTimeMarker() + `Error while stopping client for workspace folder "${workspaceFolder.name}": ${String(err)}`)
 			}
 
 			this.showChannelMessage(getTimeMarker() + `Client for workspace folder "${workspaceFolder.name}" stopped`)
@@ -399,11 +411,11 @@ export class CSSNavigationExtension {
 
 	/** Stop all clients and servers. */
 	async stopAllClients() {
-		let promises: Promise<void>[] = []
+		const promises: Promise<void>[] = []
 
 		// Snapshot the keys, since `stopClient` mutates the map while we iterate.
-		for (let uri of [...this.clients.keys()]) {
-			let workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(uri))
+		for (const uri of [...this.clients.keys()]) {
+			const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(uri))
 			if (workspaceFolder) {
 				promises.push(this.stopClient(workspaceFolder))
 			}
@@ -419,9 +431,9 @@ export class CSSNavigationExtension {
 	private watchGitIgnoreFile(workspaceFolder: vscode.WorkspaceFolder) {
 		this.unwatchLastWatchedGitIgnoreFile(workspaceFolder)
 
-		let watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(workspaceFolder.uri.fsPath, `.gitignore`))
-		let onGitIgnoreChange = () => {
-			this.restartClient(workspaceFolder)
+		const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(workspaceFolder.uri.fsPath, `.gitignore`))
+		const onGitIgnoreChange = () => {
+			void this.restartClient(workspaceFolder)
 		}
 
 		watcher.onDidCreate(onGitIgnoreChange)
@@ -433,7 +445,7 @@ export class CSSNavigationExtension {
 
 	/** unwatch `.gitignore`. */
 	private unwatchLastWatchedGitIgnoreFile(workspaceFolder: vscode.WorkspaceFolder) {
-		let watcher = this.gitIgnoreWatchers.get(workspaceFolder.uri.fsPath)
+		const watcher = this.gitIgnoreWatchers.get(workspaceFolder.uri.fsPath)
 		if (watcher) {
 			watcher.dispose()
 		}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
-import {LanguageClient, LanguageClientOptions, ServerOptions, TransportKind} from 'vscode-languageclient'
+import {LanguageClient, LanguageClientOptions, ServerOptions, TransportKind} from 'vscode-languageclient/node'
 import {getOutmostWorkspaceURI, getPathExtension, generateGlobPatternFromExtensions, getTimeMarker, fetchAsText} from './utils'
 
 
@@ -167,7 +167,7 @@ export function deactivate(): Promise<void> {
 export class CSSNavigationExtension {
 	
 	/** Channel public for testing. */
-	channel = vscode.window.createOutputChannel('CSS Navigation')
+	channel = vscode.window.createOutputChannel('CSS Navigation', {log: true})
 
 	private context: vscode.ExtensionContext
 	private config!: vscode.WorkspaceConfiguration
@@ -335,7 +335,8 @@ export class CSSNavigationExtension {
 		}
 
 		let client = new LanguageClient('css-navigation', 'CSS Navigation', serverOptions, clientOptions)
-		client.start()
+
+		// Register before awaiting `start()`, so re-entrant `ensureClient*` calls reuse this client.
 		this.clients.set(workspaceFolder.uri.toString(), client)
 
 		this.showChannelMessage(
@@ -345,6 +346,15 @@ export class CSSNavigationExtension {
 		)
 
 		this.watchGitIgnoreFile(workspaceFolder)
+
+		// Since vscode-languageclient v8+, `start()` returns a promise; await it so a failed
+		// startup is surfaced here instead of becoming an unhandled rejection.
+		try {
+			await client.start()
+		}
+		catch (err) {
+			this.showChannelMessage(getTimeMarker() + `❌ Client for workspace "${workspaceFolder.name}" failed to start: ${err}`)
+		}
 	}
 
 	private async restartClient(workspaceFolder: vscode.WorkspaceFolder) {
@@ -360,7 +370,18 @@ export class CSSNavigationExtension {
 		let client = this.clients.get(uri)
 		if (client) {
 			this.clients.delete(uri)
-			await client.stop()
+
+			// Since vscode-languageclient v8+, `stop()` rejects if the client isn't running
+			// (e.g. it's still starting up). Guard and swallow so a restart can't be left half-done.
+			try {
+				if (client.needsStop()) {
+					await client.stop()
+				}
+			}
+			catch (err) {
+				this.showChannelMessage(getTimeMarker() + `Error while stopping client for workspace folder "${workspaceFolder.name}": ${err}`)
+			}
+
 			this.showChannelMessage(getTimeMarker() + `Client for workspace folder "${workspaceFolder.name}" stopped`)
 		}
 	}
@@ -379,12 +400,17 @@ export class CSSNavigationExtension {
 	/** Stop all clients and servers. */
 	async stopAllClients() {
 		let promises: Promise<void>[] = []
-		for (let uri of this.clients.keys()) {
+
+		// Snapshot the keys, since `stopClient` mutates the map while we iterate.
+		for (let uri of [...this.clients.keys()]) {
 			let workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(uri))
 			if (workspaceFolder) {
-				this.stopClient(workspaceFolder)
+				promises.push(this.stopClient(workspaceFolder))
 			}
 		}
+
+		// Actually wait for every server to shut down before returning, so a following
+		// `ensureClients()` (on restart) can't spin up duplicate servers for the same folder.
 		await Promise.all(promises)
 		this.clients.clear()
 	}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- ambient global type, consumed across the client and server
 interface InitializationOptions {
 	workspaceFolderPath: string
 	configuration: Configuration

--- a/client/src/utils/fetch.ts
+++ b/client/src/utils/fetch.ts
@@ -7,10 +7,10 @@ import {promiseWithResolves} from './promise'
 export function fetchAsText(uri: string): Promise<string> {
 
 	// Node URL protocol has `:` in end.
-	let protocol = URL.parse(uri)?.protocol
-	let {promise, resolve, reject} = promiseWithResolves<string>()
+	const protocol = URL.parse(uri)?.protocol
+	const {promise, resolve, reject} = promiseWithResolves<string>()
 
-	let req = (protocol === 'https:' ? https : http).get(uri, (res) => {
+	const req = (protocol === 'https:' ? https : http).get(uri, (res) => {
 		let data = ''
 		
 		res.on('data', (chunk) => {

--- a/client/src/utils/path.ts
+++ b/client/src/utils/path.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 /** If a workspace folder contains another, what we need is to return the outmost one. */
 export function getOutmostWorkspaceURI(folderURI: string, allFolderURIs: string[]): string | null {
-	let parentURIs = allFolderURIs.filter(parentURI => folderURI.startsWith(parentURI + '/'))
+	const parentURIs = allFolderURIs.filter(parentURI => folderURI.startsWith(parentURI + '/'))
 	parentURIs.sort((a, b) => a.length - b.length)
 
 	return parentURIs[0] || folderURI

--- a/client/src/utils/promise.ts
+++ b/client/src/utils/promise.ts
@@ -2,15 +2,15 @@
 export function promiseWithResolves<T = void>(): {
 	promise: Promise<T>,
 	resolve: (value: T | PromiseLike<T>) => void,
-	reject: (err?: any) => void
+	reject: (reason?: unknown) => void
 } {
 	let resolve: (value: T | PromiseLike<T>) => void
-	let reject: (err: any) => void
+	let reject: (reason?: unknown) => void
 
-	let promise = new Promise((res, rej) => {
-		resolve = res as (value: T | PromiseLike<T>) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
 		reject = rej
-	}) as Promise<T>
+	})
 
 	return {
 		promise,

--- a/client/src/utils/time.ts
+++ b/client/src/utils/time.ts
@@ -1,6 +1,6 @@
 /** Generate current time marker in `h:MM:ss` format. */
 export function getTimeMarker() {
-	let date = new Date()
+	const date = new Date()
 	
 	return '['
 		+ String(date.getHours())

--- a/client/test/fixture/node_modules/test-module/imported.scss
+++ b/client/test/fixture/node_modules/test-module/imported.scss
@@ -1,0 +1,5 @@
+@import './nested';
+
+.class-imported {
+	color: red;
+}

--- a/client/test/fixture/node_modules/test-module/nested.scss
+++ b/client/test/fixture/node_modules/test-module/nested.scss
@@ -1,0 +1,3 @@
+.class-deep-imported {
+	color: red;
+}

--- a/client/test/fixture/node_modules/test-module/style-imported.scss
+++ b/client/test/fixture/node_modules/test-module/style-imported.scss
@@ -1,0 +1,3 @@
+.class-style-imported {
+	color: red;
+}

--- a/client/test/scripts/e2e.sh
+++ b/client/test/scripts/e2e.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export CODE_TESTS_PATH="$(pwd)/out"
-export CODE_TESTS_WORKSPACE="$(pwd)/fixture"
+# Resolve paths relative to this script so it works regardless of the current working directory.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-node "$(pwd)/../../client/node_modules/vscode/bin/test"
+node "$SCRIPT_DIR/../out/runTest.js"

--- a/client/test/src/file-tracking.test.ts
+++ b/client/test/src/file-tracking.test.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs'
-import * as path from 'path'
 import * as vscode from 'vscode'
 import * as assert from 'assert'
 import {sleep, getFixtureFileUri, prepare, searchSymbolNames as gs} from './helper'
@@ -7,65 +6,48 @@ import {sleep, getFixtureFileUri, prepare, searchSymbolNames as gs} from './help
 
 describe('Test CSS File Tracking', () => {
 	before(prepare)
-	let scssURI = getFixtureFileUri('css/test.scss')
+	const scssURI = getFixtureFileUri('css/test.scss')
 
 	it.skip('Should track CSS code changes come from vscode', async () => {
-		let cssDocument = await vscode.workspace.openTextDocument(scssURI)
-		let cssEditor = await vscode.window.showTextDocument(cssDocument)
-		let insertedText = '\n.class-insert-from-vscode{color: red;}\n'
+		const cssDocument = await vscode.workspace.openTextDocument(scssURI)
+		const cssEditor = await vscode.window.showTextDocument(cssDocument)
+		const insertedText = '\n.class-insert-from-vscode{color: red;}\n'
 		await cssEditor.edit(edit => {
 			edit.insert(cssDocument.positionAt(0), insertedText)
 		})
 		await sleep(1000)
-		let err
-		try{
+		try {
 			assert.deepStrictEqual(await gs(['class="', 'class-insert-from-vscode', '"']), ['.class-insert-from-vscode'])
 		}
-		catch (e) {
-			err = e
-		}
-		await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
-		if (err) {
-			throw err
+		finally {
+			await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
 		}
 	})
 
 	it.skip('Should track CSS file changes on disk', async () => {
-		let insertedText = '\n.class-insert-from-disk{color: red;}\n'
-		let rawText = fs.readFileSync(scssURI.fsPath, 'utf8')
-		let text = rawText + insertedText
+		const insertedText = '\n.class-insert-from-disk{color: red;}\n'
+		const rawText = fs.readFileSync(scssURI.fsPath, 'utf8')
+		const text = rawText + insertedText
 		fs.writeFileSync(scssURI.fsPath, text, 'utf8')
 		await sleep(1000)
-		let err
-		try{
+		try {
 			assert.deepStrictEqual(await gs(['class="', 'class-insert-from-disk', '"']), ['.class-insert-from-disk'])
 		}
-		catch (e) {
-			err = e
-		}
-		fs.writeFileSync(scssURI.fsPath, rawText, 'utf8')
-		if (err) {
-			throw err
+		finally {
+			fs.writeFileSync(scssURI.fsPath, rawText, 'utf8')
 		}
 	})
 
 	it.skip('Should track CSS file removal and creation on disk', async () => {
-		let scssText = fs.readFileSync(scssURI.fsPath, 'utf8')
+		const scssText = fs.readFileSync(scssURI.fsPath, 'utf8')
 		fs.unlinkSync(scssURI.fsPath)
 		await sleep(1000)
 
-		let err
-		try{
+		try {
 			assert.deepStrictEqual(await gs(['<', 'html', '>']), [])
 		}
-		catch (e) {
-			err = e
-		}
-
-		fs.writeFileSync(scssURI.fsPath, scssText, 'utf8')
-
-		if (err) {
-			throw err
+		finally {
+			fs.writeFileSync(scssURI.fsPath, scssText, 'utf8')
 		}
 
 		await sleep(1000)

--- a/client/test/src/helper.ts
+++ b/client/test/src/helper.ts
@@ -196,7 +196,7 @@ async function getCompletionNamesAtPosition(position: vscode.Position): Promise<
 	let completionNames = []
 
 	for (let item of list.items) {
-		completionNames.push(item.label)
+		completionNames.push(typeof item.label === 'string' ? item.label : item.label.label)
 	}
 
 	return completionNames

--- a/client/test/src/helper.ts
+++ b/client/test/src/helper.ts
@@ -1,7 +1,10 @@
 import * as path from 'path'
 import * as assert from 'assert'
 import * as vscode from 'vscode'
-import {CSSNavigationExtension} from '../../out/extension'
+
+interface ExtensionExport {
+	channel: vscode.OutputChannel
+}
 
 
 export function sleep(ms: number) {
@@ -47,8 +50,8 @@ export function getFixtureFileUri(relativePath: string): vscode.Uri {
 	return vscode.Uri.file(path.resolve(__dirname, '../fixture', relativePath))
 }
 
-async function getExtensionExport(): Promise<CSSNavigationExtension> {
-	const ext = vscode.extensions.getExtension<CSSNavigationExtension>('pucelle.vscode-css-navigation')!
+async function getExtensionExport(): Promise<ExtensionExport> {
+	const ext = vscode.extensions.getExtension<ExtensionExport>('pucelle.vscode-css-navigation')!
 	await ext.activate()
 	return ext.exports
 }

--- a/client/test/src/helper.ts
+++ b/client/test/src/helper.ts
@@ -20,7 +20,7 @@ export async function prepare() {
 
 	//wait for client to start
 	await sleep(500)
-	let extension = await getExtensionExport()
+	const extension = await getExtensionExport()
 	extension.channel.show()
 
 	htmlDocument = await vscode.workspace.openTextDocument(getFixtureFileUri('index.html'))
@@ -48,7 +48,7 @@ export function getFixtureFileUri(relativePath: string): vscode.Uri {
 }
 
 async function getExtensionExport(): Promise<CSSNavigationExtension> {
-	let ext = vscode.extensions.getExtension('pucelle.vscode-css-navigation')!
+	const ext = vscode.extensions.getExtension<CSSNavigationExtension>('pucelle.vscode-css-navigation')!
 	await ext.activate()
 	return ext.exports
 }
@@ -56,15 +56,15 @@ async function getExtensionExport(): Promise<CSSNavigationExtension> {
 
 
 export async function searchSymbolNames([start, selector, end]: [string, string, string], document: vscode.TextDocument = htmlDocument): Promise<string[] | null> {
-	let ranges = searchDocumentForContent([start, selector, end], document)
-	let searchText = start + selector + end
+	const ranges = searchDocumentForContent([start, selector, end], document)
+	const searchText = start + selector + end
 
 	if (!ranges) {
 		assert.fail(`Can't find "${searchText}" in index.html`)
 	}
 
-	let namesOfStart = await getSymbolNamesAtPosition(ranges.in.start, document)
-	let namesOfEnd = await getSymbolNamesAtPosition(ranges.in.end, document)
+	const namesOfStart = await getSymbolNamesAtPosition(ranges.in.start, document)
+	const namesOfEnd = await getSymbolNamesAtPosition(ranges.in.end, document)
 
 	assert.deepStrictEqual(namesOfStart, namesOfEnd, 'Can find same definition from start and end position')
 
@@ -81,13 +81,13 @@ export async function searchSymbolNames([start, selector, end]: [string, string,
 function searchDocumentForContent([start, content, end]: [string, string, string], document: vscode.TextDocument):
 	{in: vscode.Range, out: vscode.Range} | null
 {
-	let searchWord = start + content + end
-	let matchRange: any
-	let outerRange: any
+	const searchWord = start + content + end
+	let matchRange: vscode.Range | undefined
+	let outerRange: vscode.Range | undefined
 
 	for (let i = 0; i < document.lineCount; i++) {
-		let line = document.lineAt(i)
-		let index = line.text.indexOf(searchWord)
+		const line = document.lineAt(i)
+		const index = line.text.indexOf(searchWord)
 		if (index > -1) {
 			matchRange = new vscode.Range(
 				new vscode.Position(i, index + start.length),
@@ -106,16 +106,16 @@ function searchDocumentForContent([start, content, end]: [string, string, string
 	}
 
 	return {
-		in: matchRange!,
-		out: outerRange!
+		in: matchRange,
+		out: outerRange
 	}
 }
 
 async function getSymbolNamesAtPosition(position: vscode.Position, document: vscode.TextDocument): Promise<string[]> {
-	let locations = <vscode.Location[]>await vscode.commands.executeCommand('vscode.executeDefinitionProvider', document.uri, position)
-	let symbolNames = []
+	const locations = await vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', document.uri, position)
+	const symbolNames = []
 
-	for (let location of locations) {
+	for (const location of locations) {
 		if (location && location.range) {
 			symbolNames.push(await getCodePieceFromLocation(location))
 		}
@@ -125,16 +125,16 @@ async function getSymbolNamesAtPosition(position: vscode.Position, document: vsc
 }
 
 async function getCodePieceFromLocation(location: vscode.Location): Promise<string> {
-	let document = await vscode.workspace.openTextDocument(location.uri)
-	let text = document.getText()
+	const document = await vscode.workspace.openTextDocument(location.uri)
+	const text = document.getText()
  	return text.slice(document.offsetAt(location.range.start), document.offsetAt(location.range.end)).replace(/\s*\{[\s\S]+|\r?\n[\s\S]+/, '')
 }
 
 
 
 export async function searchWorkspaceSymbolNames(query: string): Promise<string[]> {
-	let symbols = <vscode.SymbolInformation[]>await vscode.commands.executeCommand('vscode.executeWorkspaceSymbolProvider', query)
-	let symbolNames = symbols.map(symbol => symbol.name)
+	const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>('vscode.executeWorkspaceSymbolProvider', query)
+	const symbolNames = symbols.map(symbol => symbol.name)
 
 	return symbolNames
 }
@@ -142,21 +142,21 @@ export async function searchWorkspaceSymbolNames(query: string): Promise<string[
 
 
 export async function searchReferences(searchWord: string, document: vscode.TextDocument = cssDocument): Promise<string[] | null> {
-	let ranges = searchDocumentForContent(['', searchWord, ''], document)
+	const ranges = searchDocumentForContent(['', searchWord, ''], document)
 	if (!ranges) {
 		assert.fail(`Can't find "${searchWord}" in ${path.basename(document.uri.toString())}`)
 	}
 
-	let namesOfStart = await getReferenceNamesAtPosition(ranges.in.start, document)
-	let namesOfEnd = await getReferenceNamesAtPosition(ranges.in.end, document)
+	const namesOfStart = await getReferenceNamesAtPosition(ranges.in.start, document)
+	const namesOfEnd = await getReferenceNamesAtPosition(ranges.in.end, document)
 
 	// Vscode References has some additional process, which will cause reference range changes.
 	if (namesOfStart.length !== namesOfEnd.length) {
 		assert.deepStrictEqual(namesOfStart, namesOfEnd, 'Can find same references from start and end position')
 	}
 
-	let namesOutOfStart = await getReferenceNamesAtPosition(ranges.out.start, document)
-	let namesOutOfEnd = await getReferenceNamesAtPosition(ranges.out.end, document)
+	const namesOutOfStart = await getReferenceNamesAtPosition(ranges.out.start, document)
+	const namesOutOfEnd = await getReferenceNamesAtPosition(ranges.out.end, document)
 
 	assert.ok(namesOutOfStart.length === 0, `Wrongly find reference from out of left range`)
 	assert.ok(namesOutOfEnd.length === 0, `Wrongly find reference from out of right range`)
@@ -165,12 +165,12 @@ export async function searchReferences(searchWord: string, document: vscode.Text
 }
 
 async function getReferenceNamesAtPosition(position: vscode.Position, document: vscode.TextDocument): Promise<string[]> {
-	let locations = <vscode.Location[]>await vscode.commands.executeCommand('vscode.executeReferenceProvider', document.uri, position)
-	let referenceNames = []
+	const locations = await vscode.commands.executeCommand<vscode.Location[]>('vscode.executeReferenceProvider', document.uri, position)
+	const referenceNames = []
 
-	for (let location of locations) {
+	for (const location of locations) {
 		if (location.uri.toString().endsWith('.html')) {
-			let codePiece = await getCodePieceFromLocation(location)
+			const codePiece = await getCodePieceFromLocation(location)
 			referenceNames.push(codePiece)
 		}
 	}
@@ -181,21 +181,21 @@ async function getReferenceNamesAtPosition(position: vscode.Position, document: 
 
 
 export async function searchCompletion([start, selector, end]: [string, string, string], document: vscode.TextDocument = htmlDocument): Promise<string[] | null> {
-	let searchText = start + selector + end
-	let ranges = searchDocumentForContent([start, selector, end], document)
+	const searchText = start + selector + end
+	const ranges = searchDocumentForContent([start, selector, end], document)
 	if (!ranges) {
 		assert.fail(`Can't find "${searchText}" in ${path.basename(document.uri.toString())}`)
 	}
 
-	let namesOfEnd = await getCompletionNamesAtPosition(ranges.in.end)
+	const namesOfEnd = await getCompletionNamesAtPosition(ranges.in.end)
 	return namesOfEnd
 }
 
 async function getCompletionNamesAtPosition(position: vscode.Position): Promise<string[]> {
-	let list = <vscode.CompletionList>await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', htmlDocument.uri, position)
-	let completionNames = []
+	const list = await vscode.commands.executeCommand<vscode.CompletionList>('vscode.executeCompletionItemProvider', htmlDocument.uri, position)
+	const completionNames = []
 
-	for (let item of list.items) {
+	for (const item of list.items) {
 		completionNames.push(typeof item.label === 'string' ? item.label : item.label.label)
 	}
 

--- a/client/test/src/index.ts
+++ b/client/test/src/index.ts
@@ -8,18 +8,18 @@ import Mocha from 'mocha'
  * Replaces the deprecated `vscode/lib/testrunner` from the old `vscode` package.
  */
 export function run(): Promise<void> {
-	let mocha = new Mocha({
+	const mocha = new Mocha({
 		ui: 'bdd',
 		color: true,
 		timeout: 100000,
 	})
 
-	let testsRoot = __dirname
+	const testsRoot = __dirname
 
 	return new Promise((resolve, reject) => {
 		try {
-			let files = fs.readdirSync(testsRoot).filter(file => file.endsWith('.test.js'))
-			for (let file of files) {
+			const files = fs.readdirSync(testsRoot).filter(file => file.endsWith('.test.js'))
+			for (const file of files) {
 				mocha.addFile(path.resolve(testsRoot, file))
 			}
 
@@ -33,7 +33,7 @@ export function run(): Promise<void> {
 			})
 		}
 		catch (err) {
-			reject(err)
+			reject(err instanceof Error ? err : new Error(String(err)))
 		}
 	})
 }

--- a/client/test/src/index.ts
+++ b/client/test/src/index.ts
@@ -1,14 +1,39 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
+import * as path from 'path'
+import * as fs from 'fs'
+import Mocha from 'mocha'
 
-import * as testRunner from 'vscode/lib/testrunner';
 
-testRunner.configure({
-    ui: 'bdd',
-    useColors: true,
-    timeout: 100000
-});
+/**
+ * Entry point loaded by `@vscode/test-electron` inside the Extension Host.
+ * Replaces the deprecated `vscode/lib/testrunner` from the old `vscode` package.
+ */
+export function run(): Promise<void> {
+	let mocha = new Mocha({
+		ui: 'bdd',
+		color: true,
+		timeout: 100000,
+	})
 
-module.exports = testRunner;
+	let testsRoot = __dirname
+
+	return new Promise((resolve, reject) => {
+		try {
+			let files = fs.readdirSync(testsRoot).filter(file => file.endsWith('.test.js'))
+			for (let file of files) {
+				mocha.addFile(path.resolve(testsRoot, file))
+			}
+
+			mocha.run(failures => {
+				if (failures > 0) {
+					reject(new Error(`${failures} tests failed.`))
+				}
+				else {
+					resolve()
+				}
+			})
+		}
+		catch (err) {
+			reject(err)
+		}
+	})
+}

--- a/client/test/src/runTest.ts
+++ b/client/test/src/runTest.ts
@@ -1,0 +1,32 @@
+import * as path from 'path'
+import {runTests} from '@vscode/test-electron'
+
+
+/**
+ * Downloads a VSCode instance and runs the e2e test suite in it.
+ * Replaces the deprecated `vscode/bin/test` runner from the old `vscode` package.
+ */
+async function main() {
+	try {
+		// The folder containing the extension manifest `package.json`, passed as `--extensionDevelopmentPath`.
+		let extensionDevelopmentPath = path.resolve(__dirname, '../../../')
+
+		// The compiled test entry (`index.js` exporting `run`), passed as `--extensionTestsPath`.
+		let extensionTestsPath = path.resolve(__dirname, './index')
+
+		// The workspace folder to open while running the tests.
+		let testWorkspace = path.resolve(__dirname, '../fixture')
+
+		await runTests({
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			launchArgs: [testWorkspace],
+		})
+	}
+	catch (err) {
+		console.error('Failed to run tests', err)
+		process.exit(1)
+	}
+}
+
+main()

--- a/client/test/src/runTest.ts
+++ b/client/test/src/runTest.ts
@@ -4,6 +4,9 @@ import * as os from 'os'
 import {runTests} from '@vscode/test-electron'
 
 
+const requestTimeoutMs = 60_000
+
+
 /**
  * Downloads a VSCode instance and runs the e2e test suite in it.
  * Replaces the deprecated `vscode/bin/test` runner from the old `vscode` package.
@@ -29,6 +32,7 @@ async function main() {
 		// supported `1.91.0` and the latest `stable`); defaults to `stable` locally.
 		await runTests({
 			version: process.env.VSCODE_VERSION || 'stable',
+			timeout: requestTimeoutMs,
 			extensionDevelopmentPath,
 			extensionTestsPath,
 			launchArgs: [`--user-data-dir=${userDataDir}`, testWorkspace],

--- a/client/test/src/runTest.ts
+++ b/client/test/src/runTest.ts
@@ -1,4 +1,6 @@
 import * as path from 'path'
+import * as fs from 'fs/promises'
+import * as os from 'os'
 import {runTests} from '@vscode/test-electron'
 
 
@@ -7,6 +9,9 @@ import {runTests} from '@vscode/test-electron'
  * Replaces the deprecated `vscode/bin/test` runner from the old `vscode` package.
  */
 async function main() {
+	let failed = false
+	let userDataDir: string | undefined
+
 	try {
 		// The folder containing the extension manifest `package.json`, passed as `--extensionDevelopmentPath`.
 		const extensionDevelopmentPath = path.resolve(__dirname, '../../../')
@@ -17,17 +22,29 @@ async function main() {
 		// The workspace folder to open while running the tests.
 		const testWorkspace = path.resolve(__dirname, '../fixture')
 
+		// Keep the VS Code IPC socket path short on macOS; long checkout paths can exceed its limit.
+		userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'css-nav-'))
+
 		// `VSCODE_VERSION` lets CI pin the VSCode build to test against (e.g. the oldest
 		// supported `1.91.0` and the latest `stable`); defaults to `stable` locally.
 		await runTests({
 			version: process.env.VSCODE_VERSION || 'stable',
 			extensionDevelopmentPath,
 			extensionTestsPath,
-			launchArgs: [testWorkspace],
+			launchArgs: [`--user-data-dir=${userDataDir}`, testWorkspace],
 		})
 	}
 	catch (err) {
 		console.error('Failed to run tests', err)
+		failed = true
+	}
+	finally {
+		if (userDataDir) {
+			await fs.rm(userDataDir, {recursive: true, force: true})
+		}
+	}
+
+	if (failed) {
 		process.exit(1)
 	}
 }

--- a/client/test/src/runTest.ts
+++ b/client/test/src/runTest.ts
@@ -17,7 +17,10 @@ async function main() {
 		// The workspace folder to open while running the tests.
 		const testWorkspace = path.resolve(__dirname, '../fixture')
 
+		// `VSCODE_VERSION` lets CI pin the VSCode build to test against (e.g. the oldest
+		// supported `1.91.0` and the latest `stable`); defaults to `stable` locally.
 		await runTests({
+			version: process.env.VSCODE_VERSION || 'stable',
 			extensionDevelopmentPath,
 			extensionTestsPath,
 			launchArgs: [testWorkspace],

--- a/client/test/src/runTest.ts
+++ b/client/test/src/runTest.ts
@@ -9,13 +9,13 @@ import {runTests} from '@vscode/test-electron'
 async function main() {
 	try {
 		// The folder containing the extension manifest `package.json`, passed as `--extensionDevelopmentPath`.
-		let extensionDevelopmentPath = path.resolve(__dirname, '../../../')
+		const extensionDevelopmentPath = path.resolve(__dirname, '../../../')
 
 		// The compiled test entry (`index.js` exporting `run`), passed as `--extensionTestsPath`.
-		let extensionTestsPath = path.resolve(__dirname, './index')
+		const extensionTestsPath = path.resolve(__dirname, './index')
 
 		// The workspace folder to open while running the tests.
-		let testWorkspace = path.resolve(__dirname, '../fixture')
+		const testWorkspace = path.resolve(__dirname, '../fixture')
 
 		await runTests({
 			extensionDevelopmentPath,
@@ -29,4 +29,4 @@ async function main() {
 	}
 }
 
-main()
+void main()

--- a/client/test/tsconfig.json
+++ b/client/test/tsconfig.json
@@ -1,6 +1,9 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"target": "es2018",
 		"outDir": "out",
 		"rootDir": "src",
@@ -8,7 +11,7 @@
 		"sourceMap": true,
 		"strict": true,
 		"composite": true,
-		"types": ["mocha"]
+		"types": ["mocha", "node"]
 	},
 	"include": [
 		"src"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,10 +1,16 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"moduleDetection": "legacy",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"target": "esnext",
 		"outDir": "out",
 		"rootDir": "src",
-		"lib": ["esnext"],
+		"lib": [
+			"esnext"
+		],
 		"sourceMap": true,
 		"strict": true,
 		"noUnusedLocals": true,
@@ -14,9 +20,14 @@
 		"noImplicitAny": true,
 		"noImplicitThis": true,
 		"declaration": true,
-		"composite": true
+		"composite": true,
+		"types": [
+			"node"
+		]
 	},
-	"include": ["src"],
+	"include": [
+		"src"
+	],
 	"exclude": [
 		"node_modules",
 		".vscode-test"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -26,7 +26,8 @@
 		]
 	},
 	"include": [
-		"src"
+		"src",
+		"../types/**/*.d.ts"
 	],
 	"exclude": [
 		"node_modules",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,43 @@
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+	{
+		ignores: [
+			'**/out/**',
+			'**/node_modules/**',
+			'**/.vscode-test/**',
+			'eslint.config.mjs',
+		],
+	},
+	eslint.configs.recommended,
+	tseslint.configs.recommendedTypeChecked,
+	{
+		languageOptions: {
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+		rules: {
+			'@typescript-eslint/no-deprecated': 'error',
+
+			// Allow intentionally-unused identifiers prefixed with `_` (e.g. unused handler params).
+			'@typescript-eslint/no-unused-vars': ['error', {
+				argsIgnorePattern: '^_',
+				varsIgnorePattern: '^_',
+				caughtErrorsIgnorePattern: '^_',
+			}],
+
+			// The CSS/HTML parsers deliberately over-escape special characters inside regexes for
+			// readability and consistency; such escapes are semantically harmless, and stripping
+			// them by hand in a parser is needless regression risk for no functional gain.
+			'no-useless-escape': 'off',
+
+			// TypeScript namespaces (Logger, Picker, PartConvertor, ...) are used here as a
+			// deliberate, working code-organization pattern; converting them all to ES modules
+			// would touch every import site across the server for no functional gain.
+			'@typescript-eslint/no-namespace': 'off',
+		},
+	},
+)

--- a/package.json
+++ b/package.json
@@ -220,19 +220,24 @@
 		"watch": "tsc -b -w",
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
 		"e2e-test": "sh ./client/test/scripts/e2e.sh",
+		"lint": "eslint client/src server/src client/test/src",
+		"lint:fix": "eslint client/src server/src client/test/src --fix",
 		"test": "vitest tests",
 		"package": "vsce package",
 		"publish": "vsce publish"
 	},
 	"devDependencies": {
+		"@eslint/js": "^10.0.1",
 		"@types/fs-extra": "^9.0.1",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^22.7.4",
 		"@types/vscode": "^1.91.0",
 		"@vscode/test-electron": "^2.4.1",
+		"eslint": "^10.4.1",
 		"mocha": "^11.1.0",
 		"typescript": "^6.0.0",
+		"typescript-eslint": "^8.60.1",
 		"vitest": "^3.2.4"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^22.7.4",
-		"@types/vscode": "^1.91.0",
+		"@types/vscode": "1.91.0",
 		"@vscode/test-electron": "^2.4.1",
 		"eslint": "^10.4.1",
 		"mocha": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "CSS Navigation",
 	"description": "Provides CSS Completion, Finding Definition, Finding References, Diagnostic, Hover, Workspace Symbols services for HTML, JS, TS, JSX, Vue and more languages across whole workspace",
 	"icon": "images/logo.png",
-	"version": "2.13.1",
+	"version": "2.14.0",
 	"license": "MIT",
 	"publisher": "pucelle",
 	"homepage": "https://github.com/pucelle/vscode-css-navigation",
@@ -15,7 +15,7 @@
 		"url": "https://github.com/pucelle/vscode-css-navigation/issues"
 	},
 	"engines": {
-		"vscode": "^1.51.1"
+		"vscode": "^1.91.0"
 	},
 	"categories": [
 		"Programming Languages"
@@ -227,11 +227,13 @@
 	"devDependencies": {
 		"@types/fs-extra": "^9.0.1",
 		"@types/glob": "^7.1.3",
-		"@types/minimatch": "^3.0.3",
-		"@types/mocha": "^5.2.5",
+		"@types/mocha": "^10.0.10",
 		"@types/node": "^22.7.4",
-		"vitest": "^3.2.4",
-		"vscode": "^1.1.37"
+		"@types/vscode": "^1.91.0",
+		"@vscode/test-electron": "^2.4.1",
+		"mocha": "^11.1.0",
+		"typescript": "^6.0.0",
+		"vitest": "^3.2.4"
 	},
 	"dependencies": {
 		"fs-extra": "^9.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -9,8 +9,8 @@
 		"watch": "tsc -b -w"
 	},
 	"dependencies": {
-		"vscode-languageserver": "^6.1.1",
-		"vscode-languageserver-textdocument": "^1.0.1",
-		"vscode-uri": "^2.1.2"
+		"vscode-languageserver": "^10.0.0",
+		"vscode-languageserver-textdocument": "^1.0.12",
+		"vscode-uri": "^3.1.0"
 	}
 }

--- a/server/src/code-lens.ts
+++ b/server/src/code-lens.ts
@@ -19,20 +19,20 @@ export async function getCodeLens(
 		return null
 	}
 
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
-	let codeLens: CodeLens[] = []
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const codeLens: CodeLens[] = []
 
 	if (isHTMLFile && configuration.enableDefinitionCodeLens) {
-		let diags = await getDefinitionCodeLens(document, htmlServiceMap, cssServiceMap, configuration)
+		const diags = await getDefinitionCodeLens(document, htmlServiceMap, cssServiceMap, configuration)
 		if (diags) {
 			codeLens.push(...diags)
 		}
 	}
 
 	if ((isHTMLFile || isCSSFile) && configuration.enableReferenceCodeLens) {
-		let diags = await getReferencedCodeLens(document, htmlServiceMap, cssServiceMap, configuration)
+		const diags = await getReferencedCodeLens(document, htmlServiceMap, cssServiceMap, configuration)
 		if (diags) {
 			codeLens.push(...diags)
 		}
@@ -49,14 +49,14 @@ async function getDefinitionCodeLens(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<CodeLens[] | null> {
-	let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+	const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 	if (!currentHTMLService) {
 		return null
 	}
 
-	let codeLens: CodeLens[] = []
+	const codeLens: CodeLens[] = []
 
-	let classNameParts = [
+	const classNameParts = [
 		...currentHTMLService.getPartsByType(PartType.Class),
 		...currentHTMLService.getPartsByType(PartType.ReactDefaultImportedCSSModuleClass),
 		...currentHTMLService.getPartsByType(PartType.ReactImportedCSSModuleProperty),
@@ -72,10 +72,10 @@ async function getDefinitionCodeLens(
 		await htmlServiceMap.beFresh()
 	}
 
-	for (let part of classNameParts) {
+	for (const part of classNameParts) {
 
 		// Without identifier.
-		let className = part.escapedText
+		const className = part.escapedText
 		let count = 0
 
 		count += cssServiceMap.getDefinedClassNameCount(className)
@@ -111,18 +111,18 @@ async function getReferencedCodeLens(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<CodeLens[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
-	let codeLens: CodeLens[] = []
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const codeLens: CodeLens[] = []
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
 
-		let classNameParts = currentHTMLService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
+		const classNameParts = currentHTMLService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
 		if (!classNameParts || classNameParts.length === 0) {
 			return codeLens
 		}
@@ -131,20 +131,20 @@ async function getReferencedCodeLens(
 			await htmlServiceMap.beFresh()
 		}
 
-		for (let part of classNameParts) {
+		for (const part of classNameParts) {
 
 			// Totally reference parent, no need to diagnose.
 			if (part.escapedText === '&') {
 				continue
 			}
 
-			let classNames = part.formatted
+			const classNames = part.formatted
 			let count = 0
 
-			for (let className of classNames) {
+			for (const className of classNames) {
 
 				// Without identifier.
-				let nonIdentifierClassName = className.slice(1)
+				const nonIdentifierClassName = className.slice(1)
 
 				if (configuration.enableGlobalEmbeddedCSS) {
 					count += htmlServiceMap.getReferencedClassNameCount(nonIdentifierClassName)
@@ -169,32 +169,32 @@ async function getReferencedCodeLens(
 		return codeLens
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
 
-		let classNameParts = currentCSSService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
+		const classNameParts = currentCSSService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
 		if (!classNameParts || classNameParts.length === 0) {
 			return codeLens
 		}
 
 		await htmlServiceMap.beFresh()
 
-		for (let part of classNameParts) {
+		for (const part of classNameParts) {
 			
 			// Totally reference parent, no need to diagnose.
 			if (part.escapedText === '&') {
 				continue
 			}
 
-			let classNames = part.formatted
+			const classNames = part.formatted
 			let count = 0
 
-			for (let className of classNames) {
+			for (const className of classNames) {
 
 				// Without identifier.
-				let nonIdentifierClassName = className.slice(1)
+				const nonIdentifierClassName = className.slice(1)
 
 				// Any one of formatted exist, break.
 				count += htmlServiceMap.getReferencedClassNameCount(nonIdentifierClassName)

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -12,17 +12,17 @@ export async function getCompletionItems(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<CompletionItem[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
 
-		let fromPart = currentHTMLService.findDetailedPartAt(offset)
+		const fromPart = currentHTMLService.findDetailedPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -36,12 +36,12 @@ export async function getCompletionItems(
 		return await getCompletionItemsInHTML(fromPart, currentHTMLService, document, cssServiceMap, configuration, offset)
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
 
-		let fromPart = currentCSSService.findDetailedPartAt(offset)
+		const fromPart = currentCSSService.findDetailedPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -68,8 +68,8 @@ async function getCompletionItemsInHTML(
 ): Promise<CompletionItem[] | null> {
 
 	// `#i` -> `i` to do completion is not working.
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
-	let labels = new CompletionLabels()
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
+	const labels = new CompletionLabels()
 
 	// Complete html element class name.
 	if (fromPart.isHTMLType()) {
@@ -88,7 +88,7 @@ async function getCompletionItemsInHTML(
 		}
 	}
 
-	let forceEditCollapseToOffset = fromPart.type === PartType.ClassPotential ? offset : undefined
+	const forceEditCollapseToOffset = fromPart.type === PartType.ClassPotential ? offset : undefined
 	return labels.output(fromPart, document, forceEditCollapseToOffset)
 }
 
@@ -102,8 +102,8 @@ async function getCompletionItemsInCSS(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<CompletionItem[] | null> {
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
-	let labels = new CompletionLabels()
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
+	const labels = new CompletionLabels()
 
 	// Find selector referenced completions from current document, and across all html documents.
 	// It ignores css selectors declaration completions, which will be filled by vscode.
@@ -119,7 +119,7 @@ async function getCompletionItemsInCSS(
 
 		// Remove repetitive items with current document.
 		if (configuration.disableOwnCSSVariableCompletion) {
-			let currentLabels = currentService.getReferencedCompletionLabels(fromPart)
+			const currentLabels = currentService.getReferencedCompletionLabels(fromPart)
 			labels.remove(currentLabels.keys())
 		}
 	}

--- a/server/src/core/file-tracker/file-tracker.ts
+++ b/server/src/core/file-tracker/file-tracker.ts
@@ -98,11 +98,11 @@ export abstract class FileTracker {
 
 	/** After document saved. */
 	onDocumentSaved(document: TextDocument) {
-		let fresh = this.trackingMap.isFresh(document.uri)
+		const fresh = this.trackingMap.isFresh(document.uri)
 
 		// Since `onDidChangeWatchedFiles` event was triggered so frequently, we only do updating after saved.
 		if (!fresh && this.updating) {
-			this.updateURI(document.uri)
+			void this.updateURI(document.uri)
 		}
 	}
 
@@ -115,9 +115,9 @@ export abstract class FileTracker {
 
 	/** After changes of files or folders. */
 	async onWatchedFileOrFolderChanged(params: DidChangeWatchedFilesParams) {
-		for (let change of params.changes) {
-			let uri = change.uri
-			let fsPath = URI.parse(uri).fsPath
+		for (const change of params.changes) {
+			const uri = change.uri
+			const fsPath = URI.parse(uri).fsPath
 
 			// New file or folder.
 			if (change.type === FileChangeType.Created) {
@@ -130,13 +130,13 @@ export abstract class FileTracker {
 					return
 				}
 
-				this.tryTrackFileOrFolder(fsPath, TrackingReasonMask.Included)
+				void this.tryTrackFileOrFolder(fsPath, TrackingReasonMask.Included)
 			}
 
 			// File or folder that content changed.
 			else if (change.type === FileChangeType.Changed) {
 				if (await fs.pathExists(fsPath)) {
-					let stat = await fs.stat(fsPath)
+					const stat = await fs.stat(fsPath)
 					if (stat && stat.isFile()) {
 						if (this.test.shouldTrackPath(fsPath)) {
 							this.trackPath(fsPath, TrackingReasonMask.Included)
@@ -163,12 +163,12 @@ export abstract class FileTracker {
 			return
 		}
 
-		let stat = await fs.stat(fsPath)
+		const stat = await fs.stat(fsPath)
 		if (stat.isDirectory()) {
 			await this.tryTrackFolder(fsPath, reason)
 		}
 		else if (stat.isFile()) {
-			let filePath = fsPath
+			const filePath = fsPath
 			if (this.test.shouldTrackPath(filePath)) {
 				this.trackPath(filePath, reason)
 			}
@@ -177,10 +177,10 @@ export abstract class FileTracker {
 	
 	/** Track folder. */
 	private async tryTrackFolder(folderPath: string, reason: TrackingReasonMask) {
-		let filePathsGenerator = walkDirectoryToMatchFiles(folderPath, this.ignoreFilesBy, this.maxFileCount)
+		const filePathsGenerator = walkDirectoryToMatchFiles(folderPath, this.ignoreFilesBy, this.maxFileCount)
 		let count = 0
 
-		for await (let absPath of filePathsGenerator) {
+		for await (const absPath of filePathsGenerator) {
 			if (this.test.shouldTrackPath(absPath)) {
 				this.trackPath(absPath, reason)
 				count++
@@ -200,13 +200,13 @@ export abstract class FileTracker {
 
 	/** Track or re-track file by file path, not validate whether should track here. */
 	private trackPath(filePath: string, reason: TrackingReasonMask | 0) {
-		let uri = URI.file(filePath).toString()
+		const uri = URI.file(filePath).toString()
 		this.trackURI(uri, reason)
 	}
 
 	/** Track or re-track by uri, not validate whether should track here. */
 	private trackURI(uri: string, reason: TrackingReasonMask | 0) {
-		let hasTracked = this.trackingMap.has(uri)
+		const hasTracked = this.trackingMap.has(uri)
 		this.trackingMap.trackByReason(uri, reason)
 
 		if (!hasTracked) {
@@ -222,13 +222,13 @@ export abstract class FileTracker {
 
 	/** Track or re-track opened file from document, or update tracking, no matter files inside or outside workspace. */
 	trackOpenedDocument(document: TextDocument) {
-		let uri = document.uri
-		let hasTracked = this.trackingMap.has(uri)
-		let freshBefore = this.trackingMap.isFresh(uri)
+		const uri = document.uri
+		const hasTracked = this.trackingMap.has(uri)
+		const freshBefore = this.trackingMap.isFresh(uri)
 
 		this.trackingMap.trackByDocument(document)
-		let freshAfter = this.trackingMap.isFresh(uri)
-		let expired = freshBefore && !freshAfter
+		const freshAfter = this.trackingMap.isFresh(uri)
+		const expired = freshBefore && !freshAfter
 
 		if (expired) {
 			this.afterFileExpired(uri)
@@ -244,13 +244,13 @@ export abstract class FileTracker {
 		this.onFileTracked(uri)
 
 		if (this.updating) {
-			this.updateURI(uri)
+			void this.updateURI(uri)
 		}
 	}
 
 	/** After file or folder deleted from disk. */
 	private afterDirDeleted(deletedURI: string) {
-		for (let uri of this.trackingMap.getURIs()) {
+		for (const uri of this.trackingMap.getURIs()) {
 			if (uri.startsWith(deletedURI)) {
 				this.untrackURI(uri)
 			}
@@ -263,7 +263,7 @@ export abstract class FileTracker {
 		this.onFileExpired(uri)
 
 		if (this.updating) {
-			this.updateURI(uri)
+			void this.updateURI(uri)
 		}
 	}
 
@@ -336,11 +336,11 @@ export abstract class FileTracker {
 				
 		Logger.timeStart(this.identifier + '-update')
 
-		for (let uri of this.trackingMap.getURIs()) {
+		for (const uri of this.trackingMap.getURIs()) {
 			if (!this.trackingMap.isFresh(uri)) {
 
 				// Note here not wait it.
-				this.updateURI(uri)
+				void this.updateURI(uri)
 			}
 		}
 
@@ -349,9 +349,9 @@ export abstract class FileTracker {
 
 		// May track more files and push more promises when updating.
 		while (this.updatePromiseMap.size > 0 && loopCount++ < 10) {
-			let allPromises = [...this.updatePromiseMap.values()]
+			const allPromises = [...this.updatePromiseMap.values()]
 
-			for (let promise of allPromises) {
+			for (const promise of allPromises) {
 				await promise
 			}
 
@@ -370,14 +370,14 @@ export abstract class FileTracker {
 	private async loadStartData() {
 		Logger.timeStart(this.identifier + '-track')
 
-		for (let document of this.documents.all()) {
+		for (const document of this.documents.all()) {
 			if (this.test.shouldTrackURI(document.uri)) {
 				this.trackOpenedDocument(document)
 			}
 		}
 
 		if (this.alwaysIncludeGlobSharer) {
-			let alwaysIncludePaths = await this.alwaysIncludeGlobSharer.get()
+			const alwaysIncludePaths = await this.alwaysIncludeGlobSharer.get()
 
 			for (let filePath of alwaysIncludePaths) {
 
@@ -434,17 +434,17 @@ export abstract class FileTracker {
 
 	/** Load text content and create one document. */
 	protected async loadDocument(uri: string): Promise<TextDocument | null> {
-		let languageId = path.extname(uri).slice(1).toLowerCase()
+		const languageId = path.extname(uri).slice(1).toLowerCase()
 		let document: TextDocument | null = null
-		let protocol = URI.parse(uri).scheme
+		const protocol = URI.parse(uri).scheme
 
 		if (protocol === 'http' || protocol === 'https') {
 			try {
 				
 				// Use private uri protocol to open remote files.
-				let myURI = 'css-nav-uri:' + uri
+				const myURI = 'css-nav-uri:' + uri
 
-				let text = await fetchAsText(uri)
+				const text = await fetchAsText(uri)
 				document = TextDocument.create(myURI, languageId, 1, text)
 			}
 			catch (err) {
@@ -453,7 +453,7 @@ export abstract class FileTracker {
 		}
 		else if (protocol === 'file') {
 			try {
-				let text = (await fs.readFile(URI.parse(uri).fsPath)).toString('utf8')
+				const text = (await fs.readFile(URI.parse(uri).fsPath)).toString('utf8')
 				document = TextDocument.create(uri, languageId, 1, text)
 			}
 			catch (err) {
@@ -482,7 +482,7 @@ export abstract class FileTracker {
 
 	/** Release all resources. */
 	protected releaseResources() {
-		let size = this.trackingMap.size()
+		const size = this.trackingMap.size()
 		if (size === 0) {
 			return
 		}
@@ -498,14 +498,14 @@ export abstract class FileTracker {
 
 	/** Clean imported only resource. */
 	protected clearImportedOnlyResources() {
-		let timestamp = Logger.getTimestamp() - CheckUnUsedTimeInterval
-		let uris = [...this.trackingMap.walkInActiveAndExpiredURIs(timestamp)]
+		const timestamp = Logger.getTimestamp() - CheckUnUsedTimeInterval
+		const uris = [...this.trackingMap.walkInActiveAndExpiredURIs(timestamp)]
 
 		if (uris.length === 0) {
 			return
 		}
 
-		for (let uri of uris) {
+		for (const uri of uris) {
 			this.untrackURI(uri)
 		}
 

--- a/server/src/core/file-tracker/file-walker.ts
+++ b/server/src/core/file-tracker/file-walker.ts
@@ -48,17 +48,17 @@ class FileWalker {
 
 	/** Generate relative paths relative to current directory. */
 	async *walk(): AsyncGenerator<string> {
-		let count: {value: number} = {value: 0}
+		const count: {value: number} = {value: 0}
 
-		for await(let relPath of this.walkRecursively('', [], count)) {
+		for await(const relPath of this.walkRecursively('', [], count)) {
 			yield relPath
 		}
 	}
 
 	private async *walkRecursively(relDir: string, ignoreRules: IgnoreRule[], count: {value: number}): AsyncGenerator<string> {
-		let fileNames = await fs.readdir(path.join(this.currentDir, relDir))
+		const fileNames = await fs.readdir(path.join(this.currentDir, relDir))
 
-		for (let fileName of fileNames) {
+		for (const fileName of fileNames) {
 			if (this.isIgnoreFile(fileName)) {
 
 				// Must regenerate array.
@@ -67,7 +67,7 @@ class FileWalker {
 		}
 
 		// May parallel to increase speed, but will break generator logic.
-		for (let fileName of fileNames) {
+		for (const fileName of fileNames) {
 			if (count.value >= this.maxFileCount) {
 				break
 			}
@@ -76,15 +76,15 @@ class FileWalker {
 				continue
 			}
 
-			let relPath = path.join(relDir, fileName)
-			let stat = await this.readStat(relPath)
+			const relPath = path.join(relDir, fileName)
+			const stat = await this.readStat(relPath)
 
 			if (this.matchIgnoreRules(relPath, ignoreRules)) {
 				continue
 			}
 
 			if (stat.isDirectory()) {
-				for await(let subRelPath of this.walkRecursively(relPath, ignoreRules, count)) {
+				for await(const subRelPath of this.walkRecursively(relPath, ignoreRules, count)) {
 					yield subRelPath
 				}
 			}
@@ -100,26 +100,26 @@ class FileWalker {
 	}
 
 	private async readStat(relPath: string): Promise<fs.Stats> {
-		let absPath = path.join(this.currentDir, relPath)
+		const absPath = path.join(this.currentDir, relPath)
 		return this.followSymbolLinks ? await fs.stat(absPath) : await fs.lstat(absPath)
 	}
 
 	private async parseIgnoreRules(relDir: string, fileName: string): Promise<IgnoreRule[]> {
-		let absPath = path.join(this.currentDir, relDir, fileName)
-		let text = await fs.readFile(absPath, 'utf8')
+		const absPath = path.join(this.currentDir, relDir, fileName)
+		const text = await fs.readFile(absPath, 'utf8')
 
-		let globOptions = {
+		const globOptions = {
 			matchBase: true,
 			dot: true,
 			flipNegate: true,
 			nocase: true,
 		}
 
-		let ruleLines = text.split(/\r?\n/)
+		const ruleLines = text.split(/\r?\n/)
 			.filter(line => !/^#|^$/.test(line.trim()))
 
 		// Here it doesn't supports expressions like `!XXX`.
-		let rules = ruleLines.map(pattern => {
+		const rules = ruleLines.map(pattern => {
 			if (pattern.startsWith('/')) {
 				pattern = pattern.slice(1)
 			}
@@ -141,8 +141,8 @@ class FileWalker {
 	}
 
 	private matchIgnoreRules(relPath: string, ignoreRules: IgnoreRule[]) {
-		for (let rule of ignoreRules) {
-			let pathRelToRule = path.relative(rule.relDir, relPath)
+		for (const rule of ignoreRules) {
+			const pathRelToRule = path.relative(rule.relDir, relPath)
 
 			if (rule.match.match(pathRelToRule)) {
 				return true
@@ -161,14 +161,14 @@ export async function* walkDirectoryToMatchFiles(
 	ignoreFileNames: string[],
 	maxFileCount: number = Infinity
 ): AsyncGenerator<string> {
-	let walker = new FileWalker({
+	const walker = new FileWalker({
 		currentDir,
 		ignoreFileNames,
 		followSymbolLinks: false,
 		maxFileCount,
 	})
 
-	for await(let relPath of walker.walk()) {
+	for await(const relPath of walker.walk()) {
 		yield path.join(currentDir, relPath)
 	}
 }

--- a/server/src/core/file-tracker/tracking-map.ts
+++ b/server/src/core/file-tracker/tracking-map.ts
@@ -68,7 +68,7 @@ export class TrackingMap {
 	
 	/** Walk all included and opened, or imported uris. */
 	*walkActiveURIs(): Iterable<string> {
-		for (let [uri, item] of this.trackingMap) {
+		for (const [uri, item] of this.trackingMap) {
 			if (item.reason > 0) {
 				yield uri
 			}
@@ -77,7 +77,7 @@ export class TrackingMap {
 
 	/** Walk imported only, or has no reason uris, which are also expired. */
 	*walkInActiveAndExpiredURIs(beforeTimestamp: number): Iterable<string> {
-		for (let [uri, item] of this.trackingMap) {
+		for (const [uri, item] of this.trackingMap) {
 			if (item.reason === 0 && item.latestUseTime < beforeTimestamp) {
 				yield uri
 			}
@@ -86,21 +86,21 @@ export class TrackingMap {
 
 	/** Get resolved import uris, and all their imported recursively. */
 	resolveChainedImportedURIs(uris: string[]): Iterable<string> {
-		let set: Set<string> = new Set()
+		const set: Set<string> = new Set()
 		this.resolveChainedImportedCSSPathsBySet(uris, set)
 
 		return set
 	}
 
 	private resolveChainedImportedCSSPathsBySet(uris: string[], set: Set<string>) {
-		for (let uri of uris) {
+		for (const uri of uris) {
 			if (set.has(uri)) {
 				continue
 			}
 
 			set.add(uri)
 
-			let imported = this.importMap.getByLeft(uri)
+			const imported = this.importMap.getByLeft(uri)
 			if (imported) {
 				this.resolveChainedImportedCSSPathsBySet(imported, set)
 			}
@@ -112,7 +112,7 @@ export class TrackingMap {
 	}
 
 	isFresh(uri: string): boolean {
-		let item = this.trackingMap.get(uri)
+		const item = this.trackingMap.get(uri)
 		if (!item) {
 			return false
 		}
@@ -135,7 +135,7 @@ export class TrackingMap {
 	 * Only opened document get cached.
 	 */
 	setDocument(uri: string, document: TextDocument | null) {
-		let item = this.trackingMap.get(uri)!
+		const item = this.trackingMap.get(uri)!
 
 		if (item.reason & TrackingReasonMask.Opened) {
 			item.document = document
@@ -161,22 +161,22 @@ export class TrackingMap {
 
 	/** Suggest to track both, then add import relationship. */
 	setImported(imported: string[], from: string) {
-		let changed = new Set(this.importMap.getByLeft(from))
+		const changed = new Set(this.importMap.getByLeft(from))
 
-		for (let uri of imported) {
+		for (const uri of imported) {
 			changed.add(uri)
 		}
 
 		this.importMap.replaceLeft(from, imported)
 
-		for (let uri of changed) {
+		for (const uri of changed) {
 			this.checkImportedRecursively(uri)
 		}
 	}
 
 	/** Validate after reason of `uri`, or ancestrally imported changed. */
 	private checkImportedRecursively(uri: string, depth = 5) {
-		let item = this.trackingMap.get(uri)
+		const item = this.trackingMap.get(uri)
 		if (!item) {
 			return
 		}
@@ -193,9 +193,9 @@ export class TrackingMap {
 
 		// Validate all imported reason to imported recursively.
 		if (depth > 0) {
-			let importURIs = this.importMap.getByLeft(uri)
+			const importURIs = this.importMap.getByLeft(uri)
 			if (importURIs) {
-				for (let importURI of importURIs) {
+				for (const importURI of importURIs) {
 					this.checkImportedRecursively(importURI, depth - 1)
 				}
 			}
@@ -204,12 +204,12 @@ export class TrackingMap {
 
 	/** Test whether been imported, or ancestrally imported by any included or opened. */
 	private isImportedAncestrally(uri: string, depth: number = 5): boolean {
-		let item = this.trackingMap.get(uri)
+		const item = this.trackingMap.get(uri)
 		if (!item) {
 			return false
 		}
 
-		let fromURIs = this.importMap.getByRight(uri)
+		const fromURIs = this.importMap.getByRight(uri)
 		if (!fromURIs) {
 			return false
 		}
@@ -218,8 +218,8 @@ export class TrackingMap {
 			return false
 		}
 
-		for (let fromURI of fromURIs) {
-			let fromItem = this.trackingMap.get(fromURI)!
+		for (const fromURI of fromURIs) {
+			const fromItem = this.trackingMap.get(fromURI)!
 			if (!fromItem) {
 				continue
 			}
@@ -239,12 +239,12 @@ export class TrackingMap {
 	delete(uri: string) {
 		this.trackingMap.delete(uri)
 
-		let importURIs = this.importMap.getByLeft(uri)
+		const importURIs = this.importMap.getByLeft(uri)
 		this.importMap.deleteLeft(uri)
 		this.importMap.deleteRight(uri)
 
 		if (importURIs) {
-			for (let importURI of importURIs) {
+			for (const importURI of importURIs) {
 				this.checkImportedRecursively(importURI)
 			}
 		}
@@ -294,11 +294,11 @@ export class TrackingMap {
 
 	/** Track opened document. */
 	trackByDocument(document: TextDocument) {
-		let uri = document.uri
+		const uri = document.uri
 		let item = this.trackingMap.get(uri)
 
 		if (item) {
-			let fileChanged = document.version !== item.version
+			const fileChanged = document.version !== item.version
 			item.document = document
 			item.version = document.version
 			item.reason |= TrackingReasonMask.Opened
@@ -327,7 +327,7 @@ export class TrackingMap {
 
 	/** Remove reason, if file has no reason, delete it. */
 	removeReason(uri: string, reason: TrackingReasonMask) {
-		let item = this.trackingMap.get(uri)
+		const item = this.trackingMap.get(uri)
 		if (!item) {
 			return
 		}
@@ -343,12 +343,12 @@ export class TrackingMap {
 
 	/** After knows that file get expired. */
 	private makeExpire(uri: string) {
-		let item = this.trackingMap.get(uri)
+		const item = this.trackingMap.get(uri)
 		if (!item) {
 			return
 		}
 
-		let fresh = item.fresh
+		const fresh = item.fresh
 		if (!fresh) {
 			return
 		}

--- a/server/src/core/file-tracker/tracking-test.ts
+++ b/server/src/core/file-tracker/tracking-test.ts
@@ -39,7 +39,7 @@ export class TrackingTest {
 
 	/** Returns whether should track uri. */
 	shouldTrackURI(uri: string): boolean {
-		let parsed = URI.parse(uri)
+		const parsed = URI.parse(uri)
 		if (parsed.scheme === 'file') {
 			return this.shouldTrackPath(parsed.fsPath)
 		}

--- a/server/src/core/logger.ts
+++ b/server/src/core/logger.ts
@@ -10,7 +10,7 @@ export namespace Logger {
 
 	/** Get a time marker `hh:MM:ss` for current time. */
 	function getTimeMarker() {
-		let date = new Date()
+		const date = new Date()
 		
 		return '['
 			+ String(date.getHours())
@@ -57,16 +57,16 @@ export namespace Logger {
 	}
 
 	/** Error level message. */
-	export function error(msg: any) {
+	export function error(msg: unknown) {
 		scopedConsole.info(getTimeMarker() + '❌ ' + String(msg))
 	}
 
 
 
-	let startTimeMap: Map<string, number> = new Map()
+	const startTimeMap: Map<string, number> = new Map()
 
 	export function getTimestamp(): number {
-		let time = process.hrtime()
+		const time = process.hrtime()
 		return time[0] * 1000 + time[1] / 1000000
 	}
 
@@ -77,14 +77,14 @@ export namespace Logger {
 
 	/** End a time counter with specified name. */
 	export function timeEnd(name: string, message: string | null = null) {
-		let startTime = startTimeMap.get(name)
+		const startTime = startTimeMap.get(name)
 		if (startTime === undefined) {
 			warn(`Timer "${name}" is not started`)
 			return
 		}
 
 		startTimeMap.delete(name)
-		let timeCost = Math.round(getTimestamp() - startTime!)
+		const timeCost = Math.round(getTimestamp() - startTime)
 
 		if (message !== null) {
 			log('🕒 ' + message + ` in ${timeCost} ms`)
@@ -92,13 +92,13 @@ export namespace Logger {
 	}
 
 
-	type ResultsHandler<A extends any[], T> = (...args: A) => Promise<T | null>
+	type ResultsHandler<A extends unknown[], T> = (...args: A) => Promise<T | null>
 
 	/** Log executed time of a function, which will return a list, or a single item. */
-	export function logQuerierExecutedTime<A extends any[], T>(fn: ResultsHandler<[A[0], number], T>, type: string): ResultsHandler<A, T> {
+	export function logQuerierExecutedTime<A extends unknown[], T>(fn: ResultsHandler<[A[0], number], T>, type: string): ResultsHandler<A, T> {
 		return async (...args: A) => {
-			let startTime = getTimestamp()
-			let result: Awaited<T> | null = null
+			const startTime = getTimestamp()
+			let result: Awaited<T> | null
 
 			try {
 				result = await fn(args[0], startTime)
@@ -108,7 +108,7 @@ export namespace Logger {
 				return null
 			}
 
-			let time = toDecimal(getTimestamp() - startTime!, 1)
+			const time = toDecimal(getTimestamp() - startTime, 1)
 			
 			if (Array.isArray(result)) {
 				if (result.length === 0) {

--- a/server/src/css-variable-color.ts
+++ b/server/src/css-variable-color.ts
@@ -11,12 +11,12 @@ export async function getCSSVariableColors(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<ColorInformation[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
@@ -24,7 +24,7 @@ export async function getCSSVariableColors(
 		return getCSSVariableColorsInAny(currentHTMLService, cssServiceMap, document)
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
@@ -42,35 +42,35 @@ async function getCSSVariableColorsInAny(
 	cssServiceMap: CSSServiceMap,
 	document: TextDocument
 ): Promise<ColorInformation[]> {
-	let parts = currentService.getPartsByType(PartType.CSSVariableReference)
+	const parts = currentService.getPartsByType(PartType.CSSVariableReference)
 
-	let variableNames = new Set(parts.map(part => part.escapedText))
+	const variableNames = new Set(parts.map(part => part.escapedText))
 	if (variableNames.size === 0) {
 		return []
 	}
 
-	let currentVariableMap = currentService.getCSSVariables(variableNames)
+	const currentVariableMap = currentService.getCSSVariables(variableNames)
 
 	// Stop searching if find all within current document.
 	if (currentVariableMap.size === variableNames.size) {
 		return makeColorInformation(parts, currentVariableMap, document)
 	}
 
-	let variableMap = await cssServiceMap.getCSSVariables(variableNames)
+	const variableMap = await cssServiceMap.getCSSVariables(variableNames)
 	return makeColorInformation(parts, variableMap, document)
 }
 
 
 function makeColorInformation(parts: Part[], variableMap: Map<string, string>, document: TextDocument): ColorInformation[] {
-	let items: ColorInformation[] = []
+	const items: ColorInformation[] = []
 
-	for (let part of parts) {
-		let value = variableMap.get(part.escapedText)
+	for (const part of parts) {
+		const value = variableMap.get(part.escapedText)
 		if (!value) {
 			continue
 		}
 
-		let info = PartConvertor.toColorInformation(part, value, document)
+		const info = PartConvertor.toColorInformation(part, value, document)
 		if (info) {
 			items.push(info)
 		}

--- a/server/src/definition.ts
+++ b/server/src/definition.ts
@@ -12,18 +12,18 @@ export async function findDefinitions(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<Location[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 	let locations: LocationLink[] | null = null
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
 
-		let fromPart = currentHTMLService.findPartAt(offset)
+		const fromPart = currentHTMLService.findPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -36,12 +36,12 @@ export async function findDefinitions(
 		locations = await findDefinitionsInHTML(fromPart, currentHTMLService, document, htmlServiceMap, cssServiceMap, configuration)
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
 
-		let fromPart = currentCSSService.findPartAt(offset)
+		const fromPart = currentCSSService.findPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -54,7 +54,7 @@ export async function findDefinitions(
 	}
 
 	// Sort by the longest common subsequence.
-	let items = locations.map(l => {
+	const items = locations.map(l => {
 		return {
 			location: l,
 			subsequence: getLongestCommonSubsequenceLength(l.targetUri, document.uri),
@@ -80,13 +80,13 @@ async function findDefinitionsInHTML(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<LocationLink[] | null> {
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
-	let locations: LocationLink[] = []
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
+	const locations: LocationLink[] = []
 
 
 	// When mouse locates at `<link rel="stylesheet" href="|...|">` or `<style src="|...|">`, goto file start.
 	if (fromPart.type === PartType.CSSImportPath) {
-		let link = await PathResolver.resolveImportLocationLink(fromPart, document)
+		const link = await PathResolver.resolveImportLocationLink(fromPart, document)
 		if (!link) {
 			return null
 		}
@@ -97,15 +97,15 @@ async function findDefinitionsInHTML(
 
 	// When mouse locates at `styleName="class-name"`, search within default imported css module.
 	if (fromPart.type === PartType.ReactDefaultImportedCSSModuleClass) {
-		let filePaths = await ModuleResolver.resolveReactDefaultCSSModuleURIs(document)
+		const filePaths = await ModuleResolver.resolveReactDefaultCSSModuleURIs(document)
 
-		for (let filePath of filePaths) {
-			let cssModuleService = await cssServiceMap.forceGetServiceByURI(filePath)
+		for (const filePath of filePaths) {
+			const cssModuleService = await cssServiceMap.forceGetServiceByURI(filePath)
 			if (!cssModuleService) {
 				return null
 			}
 
-			let defs = cssModuleService.findDefinitions(matchPart, fromPart, document)
+			const defs = cssModuleService.findDefinitions(matchPart, fromPart, document)
 			if (defs.length > 0) {
 				return defs
 			}
@@ -117,17 +117,17 @@ async function findDefinitionsInHTML(
 
 	// When mouse locates at `class={style.className}`, search within specified named imported css module.
 	if (fromPart.type === PartType.ReactImportedCSSModuleProperty) {
-		let importedCSSModulePart = currentService.findPreviousPart(fromPart)
+		const importedCSSModulePart = currentService.findPreviousPart(fromPart)
 		if (!importedCSSModulePart || importedCSSModulePart.type !== PartType.ReactImportedCSSModuleName) {
 			return null
 		}
 
-		let uri = await ModuleResolver.resolveReactCSSModuleURIByName(importedCSSModulePart.escapedText, document)
+		const uri = await ModuleResolver.resolveReactCSSModuleURIByName(importedCSSModulePart.escapedText, document)
 		if (!uri) {
 			return null
 		}
 
-		let cssModuleService = await cssServiceMap.forceGetServiceByURI(uri)
+		const cssModuleService = await cssServiceMap.forceGetServiceByURI(uri)
 		if (!cssModuleService) {
 			return null
 		}
@@ -186,7 +186,7 @@ async function findDefinitionsInCSS(
 
 	// When mouse locates at `@import`, goto file start.
 	if (fromPart.type === PartType.CSSImportPath) {
-		let link = await PathResolver.resolveImportLocationLink(fromPart, document)
+		const link = await PathResolver.resolveImportLocationLink(fromPart, document)
 		if (!link) {
 			return null
 		}
@@ -200,8 +200,8 @@ async function findDefinitionsInCSS(
 	}
 
 
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
-	let locations: LocationLink[] = []
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
+	const locations: LocationLink[] = []
 
 
 	// For `var(--variable-name)`, find at current document or imported.
@@ -228,7 +228,7 @@ async function findEmbeddedOrImported(
 	document: TextDocument,
 	cssServiceMap: CSSServiceMap
 ): Promise<LocationLink[]> {
-	let locations: LocationLink[] = []
+	const locations: LocationLink[] = []
 
 	// Find embedded style definitions, if found, stop.
 	locations.push(...currentService.findDefinitions(matchPart, fromPart, document))
@@ -239,11 +239,11 @@ async function findEmbeddedOrImported(
 	
 
 	// Having CSS files imported, firstly search within these files, if found, not searching more.
-	let cssURIs = await currentService.getImportedCSSURIs()
-	let cssURIChain = cssServiceMap.trackingMap.resolveChainedImportedURIs(cssURIs)
+	const cssURIs = await currentService.getImportedCSSURIs()
+	const cssURIChain = cssServiceMap.trackingMap.resolveChainedImportedURIs(cssURIs)
 
-	for (let cssURI of cssURIChain) {
-		let cssService = await cssServiceMap.forceGetServiceByURI(cssURI)
+	for (const cssURI of cssURIChain) {
+		const cssService = await cssServiceMap.forceGetServiceByURI(cssURI)
 		if (!cssService) {
 			continue
 		}

--- a/server/src/diagnostic.ts
+++ b/server/src/diagnostic.ts
@@ -12,27 +12,27 @@ export async function getDiagnostics(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<Diagnostic[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
-	let shouldProvideDefDiag = isHTMLFile && configuration.enableClassNameDefinitionDiagnostic
-	let shouldProvideRefDiag = (isHTMLFile || isCSSFile) && configuration.enableClassNameReferenceDiagnostic
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const shouldProvideDefDiag = isHTMLFile && configuration.enableClassNameDefinitionDiagnostic
+	const shouldProvideRefDiag = (isHTMLFile || isCSSFile) && configuration.enableClassNameReferenceDiagnostic
 
 	if (!shouldProvideDefDiag && !shouldProvideRefDiag) {
 		return null
 	}
 
-	let diagnostics: Diagnostic[] = []
+	const diagnostics: Diagnostic[] = []
 
 	if (shouldProvideDefDiag) {
-		let diags = await getDefinitionDiagnostics(document, htmlServiceMap, cssServiceMap, configuration)
+		const diags = await getDefinitionDiagnostics(document, htmlServiceMap, cssServiceMap, configuration)
 		if (diags) {
 			diagnostics.push(...diags)
 		}
 	}
 
 	if (shouldProvideRefDiag) {
-		let diags = await getReferencedDiagnostics(document, htmlServiceMap, cssServiceMap, configuration)
+		const diags = await getReferencedDiagnostics(document, htmlServiceMap, cssServiceMap, configuration)
 		if (diags) {
 			diagnostics.push(...diags)
 		}
@@ -49,14 +49,14 @@ async function getDefinitionDiagnostics(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<Diagnostic[] | null> {
-	let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+	const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 	if (!currentHTMLService) {
 		return null
 	}
 
-	let diagnostics: Diagnostic[] = []
+	const diagnostics: Diagnostic[] = []
 
-	let classNameParts = currentHTMLService.getPartsByType(PartType.Class)
+	const classNameParts = currentHTMLService.getPartsByType(PartType.Class)
 	if (!classNameParts || classNameParts.length === 0) {
 		return diagnostics
 	}
@@ -67,10 +67,10 @@ async function getDefinitionDiagnostics(
 		await htmlServiceMap.beFresh()
 	}
 
-	for (let part of classNameParts) {
+	for (const part of classNameParts) {
 
 		// Without identifier.
-		let className = part.escapedText
+		const className = part.escapedText
 
 		if (currentHTMLService.hasDefinedClassName(className)) {
 			continue
@@ -106,18 +106,18 @@ async function getReferencedDiagnostics(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<Diagnostic[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
-	let diagnostics: Diagnostic[] = []
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const diagnostics: Diagnostic[] = []
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
 
-		let classNameParts = currentHTMLService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
+		const classNameParts = currentHTMLService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
 		if (!classNameParts || classNameParts.length === 0) {
 			return diagnostics
 		}
@@ -126,19 +126,19 @@ async function getReferencedDiagnostics(
 			await htmlServiceMap.beFresh()
 		}
 
-		for (let part of classNameParts) {
+		for (const part of classNameParts) {
 
 			// Totally reference parent, no need to diagnose.
 			if (part.escapedText === '&') {
 				continue
 			}
 
-			let classNames = part.formatted
+			const classNames = part.formatted
 
-			for (let className of classNames) {
+			for (const className of classNames) {
 
 				// Without identifier.
-				let nonIdentifierClassName = className.slice(1)
+				const nonIdentifierClassName = className.slice(1)
 
 				// Find only within current document.
 				// Any one of formatted exist, break.
@@ -154,7 +154,7 @@ async function getReferencedDiagnostics(
 				}
 
 				// Has `@css-ignore` comment.
-				let wrapper = part.getWrapper(currentHTMLService)
+				const wrapper = part.getWrapper(currentHTMLService)
 				if (wrapper && wrapper.comment?.includes('@css-ignore')) {
 					break
 				}
@@ -172,31 +172,31 @@ async function getReferencedDiagnostics(
 		return diagnostics
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
 
-		let classNameParts = currentCSSService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
+		const classNameParts = currentCSSService.getPartsByType(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
 		if (!classNameParts || classNameParts.length === 0) {
 			return diagnostics
 		}
 
 		await htmlServiceMap.beFresh()
 
-		for (let part of classNameParts) {
+		for (const part of classNameParts) {
 
 			// Totally reference parent, no need to diagnose.
 			if (part.escapedText === '&') {
 				continue
 			}
 
-			let classNames = part.formatted
+			const classNames = part.formatted
 
-			for (let className of classNames) {
+			for (const className of classNames) {
 
 				// Without identifier.
-				let nonIdentifierClassName = className.slice(1)
+				const nonIdentifierClassName = className.slice(1)
 
 				// Any one of formatted exist, break.
 				if (htmlServiceMap.hasReferencedClassName(nonIdentifierClassName)) {
@@ -204,7 +204,7 @@ async function getReferencedDiagnostics(
 				}
 
 				// Has `@css-ignore` comment.
-				let wrapper = part.getWrapper(currentCSSService)
+				const wrapper = part.getWrapper(currentCSSService)
 				if (wrapper && wrapper.comment?.includes('@css-ignore')) {
 					break
 				}

--- a/server/src/hover.ts
+++ b/server/src/hover.ts
@@ -12,17 +12,17 @@ export async function findHover(
 	cssServiceMap: CSSServiceMap,
 	configuration: Configuration
 ): Promise<Hover | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
 
-		let fromPart = currentHTMLService.findDetailedPartAt(offset)
+		const fromPart = currentHTMLService.findDetailedPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -35,12 +35,12 @@ export async function findHover(
 		return await findHoverInHTML(fromPart, currentHTMLService, document, htmlServiceMap, cssServiceMap, configuration)
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
 
-		let fromPart = currentCSSService.findDetailedPartAt(offset)
+		const fromPart = currentCSSService.findDetailedPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -65,8 +65,8 @@ async function findHoverInHTML(
 		return null
 	}
 
-	let hover: Hover | null = null
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
+	let hover: Hover | null
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
 
 
 	if (fromPart.isSelectorType() || fromPart.isCSSVariableType()) {
@@ -111,8 +111,8 @@ async function findHoverInCSS(
 		return null
 	}
 
-	let hover: Hover | null = null
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
+	let hover: Hover | null
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
 
 	if (fromPart.isCSSVariableType()) {
 
@@ -143,23 +143,23 @@ async function findEmbeddedOrImported(
 ): Promise<Hover | null> {
 
 	// Find embedded hover.
-	let hover = currentService.findHover(matchPart, fromPart, document, configuration.maxHoverStylePropertyCount)
+	const hover = currentService.findHover(matchPart, fromPart, document, configuration.maxHoverStylePropertyCount)
 	if (hover) {
 		return hover
 	}
 	
 
 	// Having CSS files imported, firstly search within these files, if found, not searching more.
-	let cssURIs = await currentService.getImportedCSSURIs()
-	let cssURIChain = cssServiceMap.trackingMap.resolveChainedImportedURIs(cssURIs)
+	const cssURIs = await currentService.getImportedCSSURIs()
+	const cssURIChain = cssServiceMap.trackingMap.resolveChainedImportedURIs(cssURIs)
 
-	for (let cssURI of cssURIChain) {
-		let cssService = await cssServiceMap.forceGetServiceByURI(cssURI)
+	for (const cssURI of cssURIChain) {
+		const cssService = await cssServiceMap.forceGetServiceByURI(cssURI)
 		if (!cssService) {
 			continue
 		}
 
-		let hover = cssService.findHover(matchPart, fromPart, document, configuration.maxHoverStylePropertyCount)
+		const hover = cssService.findHover(matchPart, fromPart, document, configuration.maxHoverStylePropertyCount)
 		if (hover) {
 			return hover
 		}

--- a/server/src/languages/class-names-in-js.ts
+++ b/server/src/languages/class-names-in-js.ts
@@ -1,5 +1,5 @@
 import {Part, PartType} from './parts'
-import {Picked, Picker} from './trees'
+import {Picker} from './trees'
 
 
 /** 
@@ -16,19 +16,19 @@ export namespace ClassNamesInJS {
 
 	/** Set variable names wild match expressions. */
 	export function initWildNames(wildNames: string[]) {
-		let nameSource = wildNames.map(n => n.replace(/\*/g, '\\w*?')).join('|')
+		const nameSource = wildNames.map(n => n.replace(/\*/g, '\\w*?')).join('|')
 
 		try {
 			nameMatchRegExp = new RegExp('^' + nameSource + '$', '')
 
-			let wrappedNameSource = '(?:' + nameSource + ')'
+			const wrappedNameSource = '(?:' + nameSource + ')'
 
 			expressionMathRegExp = new RegExp(
 				`\\b(?:let|var|const)\\s+${wrappedNameSource}\\s*=\\s*["'\`]([\\w-]*?)["'\`]|\\.${wrappedNameSource}\\s*=\\s*["'\`]([\\w-]*?)["'\`]|[{,]\\s*${wrappedNameSource}\\s*:\\s*["'\`]([\\w-]*?)["'\`]`,
 				'gi'
 			)
 		}
-		catch (err) {}
+		catch { /* ignore invalid user-supplied wild-name pattern; leave the regex unset */ }
 	}
 
 
@@ -44,14 +44,14 @@ export namespace ClassNamesInJS {
 			return
 		}
 
-		let matches = Picker.locateAllMatches(
+		const matches = Picker.locateAllMatches(
 			text,
 			expressionMathRegExp,
 			[1, 2, 3]
 		)
 
-		for (let match of matches as  Iterable<Record<1 | 2 | 3, Picked>>) {
-			let subMatch = match[1] ?? match[2] ?? match[3]
+		for (const match of matches) {
+			const subMatch = match[1] ?? match[2] ?? match[3]
 			if (subMatch) {
 				yield (new Part(PartType.Class, subMatch.text, subMatch.start + start)).trim()
 			}

--- a/server/src/languages/language-ids/types.ts
+++ b/server/src/languages/language-ids/types.ts
@@ -2,4 +2,5 @@ type CSSLanguageId = 'css' | 'sass' | 'scss' | 'less'
 
 type HTMLLanguageId = 'jsx' | 'tsx' | 'js' | 'ts' | 'html' | 'vue'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- ambient global type, consumed across the server
 type AllLanguageId = HTMLLanguageId | CSSLanguageId

--- a/server/src/languages/parts/completion-labels.ts
+++ b/server/src/languages/parts/completion-labels.ts
@@ -20,7 +20,7 @@ export class CompletionLabels {
 	private detailMap: Map<string, CompletionLabel | null> = new Map()
 
 	add(type: CompletionLabelType, labelMap: Map<string, CompletionLabel | null>) {
-		for (let [label, detail] of labelMap) {
+		for (const [label, detail] of labelMap) {
 			if (!this.typeMap.has(label) || this.typeMap.get(label)! < type) {
 				this.typeMap.set(label, type)
 				this.detailMap.set(label, detail)
@@ -29,7 +29,7 @@ export class CompletionLabels {
 	}
 
 	remove(labels: Iterable<string>) {
-		for (let label of labels) {
+		for (const label of labels) {
 			this.typeMap.delete(label)
 
 			// No need to delete details, wait them to be GC.
@@ -38,15 +38,15 @@ export class CompletionLabels {
 
 	/** If `forceForOffset` specified, reset text edit to this offset. */
 	output(fromPart: Part, document: TextDocument, forceEditCollapseToOffset: number | undefined = undefined): CompletionItem[] {
-		let items: CompletionItem[] = []
+		const items: CompletionItem[] = []
 
-		let collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base', ignorePunctuation: true})
-		let sortedTexts = [...this.typeMap.keys()].sort(collator.compare)
+		const collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base', ignorePunctuation: true})
+		const sortedTexts = [...this.typeMap.keys()].sort((a, b) => collator.compare(a, b))
 
 		for (let i = 0; i < sortedTexts.length; i++) {
 			let kind: CompletionItemKind
-			let text = sortedTexts[i]
-			let type = this.typeMap.get(text)
+			const text = sortedTexts[i]
+			const type = this.typeMap.get(text)
 
 			if (type === CompletionLabelType.CSSVariable) {
 				kind = CompletionItemKind.Variable
@@ -58,12 +58,12 @@ export class CompletionLabels {
 				kind = CompletionItemKind.Value
 			}
 
-			let label = this.detailMap.get(text)
+			const label = this.detailMap.get(text)
 			let detail = label?.text
 
 			// Completion supports only HEX color type.
 			if (type === CompletionLabelType.CSSVariable && detail) {
-				let color = Color.fromString(detail)
+				const color = Color.fromString(detail)
 				if (color) {
 					kind = CompletionItemKind.Color
 					detail = color.toHEX()
@@ -73,10 +73,10 @@ export class CompletionLabels {
 			// Before completion items expanded, shows detail,
 			// After expanded, shows documentation.
 			// If both provided, shows detail + documentation after expanded.
-			let documentation = label?.markdown
+			const documentation = label?.markdown
 
 			// Use space because it's char code is 32, lower than any other visible characters.
-			let sortText = ' ' + String(i).padStart(3, '0')
+			const sortText = ' ' + String(i).padStart(3, '0')
 			let insertText = text
 			let command: Command | undefined
 			
@@ -86,7 +86,7 @@ export class CompletionLabels {
 			}
 
 			// Reset text edit collapse to the specified offset.
-			let range = PartConvertor.toRange(fromPart, document)
+			const range = PartConvertor.toRange(fromPart, document)
 			if (forceEditCollapseToOffset !== undefined) {
 				range.start = range.end = document.positionAt(forceEditCollapseToOffset)
 			}
@@ -97,12 +97,12 @@ export class CompletionLabels {
 				command = Command.create('Move cursor forward for one character', 'CSSNavigation.moveCursorForward')
 			}
 
-			let textEdit = TextEdit.replace(
+			const textEdit = TextEdit.replace(
 				PartConvertor.toRange(fromPart, document),
 				insertText,
 			)
 
-			let item: CompletionItem = {
+			const item: CompletionItem = {
 				kind,
 				label: text,
 				detail,

--- a/server/src/languages/parts/part-convertor.ts
+++ b/server/src/languages/parts/part-convertor.ts
@@ -163,8 +163,8 @@ export namespace PartConvertor {
 	 * so can transform to definition mode to make comparing faster.
 	 */
 	export function toDefinitionMode(part: Part): Part {
-		let type = PartConvertor.typeToDefinition(part.type)
-		let text = PartConvertor.textToType(part.escapedText, part.type, type)
+		const type = PartConvertor.typeToDefinition(part.type)
+		const text = PartConvertor.textToType(part.escapedText, part.type, type)
 
 		return new Part(type, text, -1, -1)
 	}
@@ -178,13 +178,13 @@ export namespace PartConvertor {
 
 	/** To a location link for going to definition. */
 	export function toLocationLink(part: Part, document: TextDocument, fromPart: Part, fromDocument: TextDocument) {
-		let selectionRange = toRange(part, document)
-		let end = part.defEnd > -1 ? part.defEnd : part.end
+		const selectionRange = toRange(part, document)
+		const end = part.defEnd > -1 ? part.defEnd : part.end
 
 		// Selection range doesn't work as expected, finally cursor move to definition start.
-		let definitionRange = Range.create(selectionRange.start, document.positionAt(end))
+		const definitionRange = Range.create(selectionRange.start, document.positionAt(end))
 
-		let fromRange = toRange(fromPart, fromDocument)
+		const fromRange = toRange(fromPart, fromDocument)
 
 		return LocationLink.create(document.uri, definitionRange, selectionRange, fromRange)
 	}
@@ -196,14 +196,14 @@ export namespace PartConvertor {
 
 	/** To several symbol information for workspace symbol searching. */
 	export function toSymbolInformationList(part: Part, document: TextDocument): SymbolInformation[] {
-		let kind = part.type === PartType.CSSSelectorWrapper
+		const kind = part.type === PartType.CSSSelectorWrapper
 			|| part.type === PartType.CSSSelectorTag
 			|| part.type === PartType.CSSSelectorClass
 			|| part.type === PartType.CSSSelectorId
 				? SymbolKind.Class
 				: SymbolKind.Variable
 
-		let textList = PartComparer.mayFormatted(part)
+		const textList = PartComparer.mayFormatted(part)
 
 		return textList.map(text => SymbolInformation.create(
 			text,
@@ -216,7 +216,7 @@ export namespace PartConvertor {
 	/** Selector part to hover. */
 	export function toHoverOfSelectorWrapper(part: CSSSelectorWrapperPart, fromPart: Part, document: TextDocument, fromDocument: TextDocument, maxStylePropertyCount: number): Hover {
 		let content = getSelectorStyleContent(part, document, maxStylePropertyCount)
-		let comment = part.comment?.trim()
+		const comment = part.comment?.trim()
 
 		if (comment) {
 			content = comment + '\n' + content
@@ -249,18 +249,18 @@ export namespace PartConvertor {
 	}
 
 	function parseStyleProperties(part: CSSSelectorWrapperPart, string: string, maxStylePropertyCount: number): string {
-		let text = string.slice(part.start, part.defEnd)
-		let tree = CSSTokenTree.fromString(text, 0, 'css')
+		const text = string.slice(part.start, part.defEnd)
+		const tree = CSSTokenTree.fromString(text, 0, 'css')
 		let content = ''
 		let count = 0
 		let hasAdditional = false
-		let selectorNode = tree.children!.find(child => child.type === CSSTokenNodeType.Selector)
+		const selectorNode = tree.children!.find(child => child.type === CSSTokenNodeType.Selector)
 
 		if (!selectorNode) {
 			return '...'
 		}
 
-		for (let child of selectorNode.children!) {
+		for (const child of selectorNode.children!) {
 			if (count === maxStylePropertyCount) {
 				hasAdditional = true
 				break
@@ -298,8 +298,8 @@ export namespace PartConvertor {
 
 	/** CSS Variable definition part to hover. */
 	export function toHoverOfCSSVariableDefinition(part: CSSVariableDefinitionPart, fromPart: Part, fromDocument: TextDocument): Hover | null {
-		let comment = part.comment?.trim()
-		let value = part.value?.trim()
+		const comment = part.comment?.trim()
+		const value = part.value?.trim()
 		let content = ''
 
 		if (value) {
@@ -322,7 +322,7 @@ export namespace PartConvertor {
 
 	/** CSS Variable part to color information. */
 	export function toColorInformation(part: Part, value: string, fromDocument: TextDocument): ColorInformation | null {
-		let color = Color.fromString(value)
+		const color = Color.fromString(value)
 		if (!color) {
 			return null
 		}

--- a/server/src/languages/parts/part-css-selector-detailed.ts
+++ b/server/src/languages/parts/part-css-selector-detailed.ts
@@ -55,7 +55,7 @@ export class CSSSelectorDetailedPart extends Part {
 
 	/** Get parent selector wrapper. */
 	getWrapper(service: BaseService): CSSSelectorWrapperPart | null {
-		let wrapperPart = service.findPartAt(this.start) as CSSSelectorWrapperPart | undefined
+		const wrapperPart = service.findPartAt(this.start) as CSSSelectorWrapperPart | undefined
 		return wrapperPart ?? null
 	}
 }
@@ -68,13 +68,13 @@ export function parseDetailedParts(
 	definitionEnd: number,
 	commandWrapped: boolean
 ): CSSSelectorDetailedPart[] {
-	let detailedTokens = group.filter(item => item.type === CSSSelectorTokenType.Tag
+	const detailedTokens = group.filter(item => item.type === CSSSelectorTokenType.Tag
 		|| item.type === CSSSelectorTokenType.Nesting
 		|| item.type === CSSSelectorTokenType.Class
 		|| item.type === CSSSelectorTokenType.Id)
 		
 	let primaryToken = detailedTokens.length > 0 ? detailedTokens[detailedTokens.length - 1] : null
-	let primaryTokenIndex = primaryToken ? group.lastIndexOf(primaryToken) : -1
+	const primaryTokenIndex = primaryToken ? group.lastIndexOf(primaryToken) : -1
 
 	// Has combinator or separator followed.
 	// `a b` -> `b`
@@ -84,7 +84,7 @@ export function parseDetailedParts(
 	// `.a::before` -> `null`
 	if (primaryTokenIndex !== -1) {
 		for (let i = primaryTokenIndex + 1; i < group.length; i++) {
-			let item = group[i]
+			const item = group[i]
 
 			if (item.type === CSSSelectorTokenType.Combinator
 				|| item.type === CSSSelectorTokenType.Separator
@@ -96,10 +96,10 @@ export function parseDetailedParts(
 		}
 	}
 
-	let details: CSSSelectorDetailedPart[] = []
-	let independent = commandWrapped || group.length === 1
+	const details: CSSSelectorDetailedPart[] = []
+	const independent = commandWrapped || group.length === 1
 
-	for (let token of detailedTokens) {
+	for (const token of detailedTokens) {
 		let formatted = joinMainReferenceSelectorWithParent(token, parents)
 		if (formatted.length === 0) {
 			continue
@@ -107,9 +107,9 @@ export function parseDetailedParts(
 
 		formatted = formatted.map(escapedCSSSelector)
 
-		let type = getDetailedPartType(token.type, formatted)
-		let primary = token === primaryToken
-		let part = new CSSSelectorDetailedPart(type, token.text, token.start, definitionEnd, formatted, primary, independent)
+		const type = getDetailedPartType(token.type, formatted)
+		const primary = token === primaryToken
+		const part = new CSSSelectorDetailedPart(type, token.text, token.start, definitionEnd, formatted, primary, independent)
 
 		details.push(part)
 	}
@@ -120,8 +120,8 @@ export function parseDetailedParts(
 
 /** Join parent selectors, but only handle `&-` joining. */
 function joinMainReferenceSelectorWithParent(token: CSSSelectorToken, parents: CSSSelectorWrapperPart[] | undefined): string[] {
-	let text = token.text
-	let re = /&/g
+	const text = token.text
+	const re = /&/g
 
 	// `a{&-b}` -> `a-b`, not handle joining multiply & when several `&` exist.
 	if (re.test(text)) {
@@ -129,14 +129,14 @@ function joinMainReferenceSelectorWithParent(token: CSSSelectorToken, parents: C
 			return [text]
 		}
 
-		let joint: string[] = []
+		const joint: string[] = []
 
-		for (let parent of parents) {
+		for (const parent of parents) {
 			if (!parent.primary) {
 				continue
 			}
 
-			for (let primaryFormatted of parent.primary.formatted) {
+			for (const primaryFormatted of parent.primary.formatted) {
 				joint.push(text.replace(re, primaryFormatted))
 			}
 		}

--- a/server/src/languages/parts/part-css-selector-wrapper.ts
+++ b/server/src/languages/parts/part-css-selector-wrapper.ts
@@ -19,8 +19,8 @@ export class CSSSelectorWrapperPart extends Part {
 		commandWrapped: boolean,
 		comment: string | undefined
 	) {
-		let formatted = parseFormatted(jointToken, parents, breaksSeparatorNesting)
-		let details = parseDetailedParts(group, parents, definitionEnd, commandWrapped)
+		const formatted = parseFormatted(jointToken, parents, breaksSeparatorNesting)
+		const details = parseDetailedParts(group, parents, definitionEnd, commandWrapped)
 
 		return new CSSSelectorWrapperPart(jointToken.text, jointToken.start, definitionEnd, comment, formatted, details)
 	}
@@ -78,8 +78,8 @@ function parseFormatted(jointToken: CSSSelectorToken, parents: CSSSelectorWrappe
 
 /** Join parent selectors. */
 function joinSelectorWithParent(token: CSSSelectorToken, parents: CSSSelectorWrapperPart[] | undefined, breaksSeparatorNesting: boolean): string[] {
-	let text = token.text
-	let re = /&/g
+	const text = token.text
+	const re = /&/g
 
 	if (!parents || parents.length === 0) {
 		return [text]
@@ -87,10 +87,10 @@ function joinSelectorWithParent(token: CSSSelectorToken, parents: CSSSelectorWra
 
 	// `a{&-b}` -> `a-b`.
 	if (re.test(text)) {
-		let joint: string[] = []
+		const joint: string[] = []
 
-		for (let parent of parents) {
-			for (let parentText of parent.formatted) {
+		for (const parent of parents) {
+			for (const parentText of parent.formatted) {
 				joint.push(text.replace(re, parentText))
 			}
 		}
@@ -100,10 +100,10 @@ function joinSelectorWithParent(token: CSSSelectorToken, parents: CSSSelectorWra
 
 	// `a{b}` -> `a b`.
 	else if (!breaksSeparatorNesting) {
-		let joint: string[] = []
+		const joint: string[] = []
 
-		for (let parent of parents) {
-			for (let parentText of parent.formatted) {
+		for (const parent of parents) {
+			for (const parentText of parent.formatted) {
 				joint.push(parentText + ' ' + text)
 			}
 		}

--- a/server/src/languages/resolver/module.ts
+++ b/server/src/languages/resolver/module.ts
@@ -11,23 +11,23 @@ export namespace ModuleResolver {
 	 * By a `ReactImportedCSSModuleName` type of part.
 	 */
 	export async function resolveReactCSSModuleURIByName(moduleName: string, document: TextDocument): Promise<string | null> {
-		let text = document.getText()
-		let modulePath = resolveDefaultImportedPathByVariableName(moduleName, text)
+		const text = document.getText()
+		const modulePath = resolveDefaultImportedPathByVariableName(moduleName, text)
 		if (!modulePath) {
 			return null
 		}
 
-		let uri = await PathResolver.resolveImportURI(modulePath, document)
+		const uri = await PathResolver.resolveImportURI(modulePath, document)
 		return uri
 	}
 
 	/** Try resolve `path` by matching `import name from path` after known `name`. */
 	function resolveDefaultImportedPathByVariableName(variableName: string, text: string): string | null {
-		let re = /import\s+(?=\*\s+as\s+)?(\w+)\s+from\s+['"`](.+?)['"`]/g
+		const re = /import\s+(?=\*\s+as\s+)?(\w+)\s+from\s+['"`](.+?)['"`]/g
 		let match: RegExpExecArray | null
 
-		while (match = re.exec(text)) {
-			let name = match[1]
+		while ((match = re.exec(text)) !== null) {
+			const name = match[1]
 			if (name === variableName) {
 				return match[2]
 			}
@@ -42,11 +42,11 @@ export namespace ModuleResolver {
 	 * By a `ReactDefaultCSSModule` type of part.
 	 */
 	export async function resolveReactDefaultCSSModuleURIs(document: TextDocument): Promise<string[]> {
-		let text = document.getText()
-		let uris: string[] = []
+		const text = document.getText()
+		const uris: string[] = []
 
-		for (let modulePath of resolveNonNamedImportedPaths(text)) {
-			let uri = await PathResolver.resolveImportURI(modulePath, document)
+		for (const modulePath of resolveNonNamedImportedPaths(text)) {
+			const uri = await PathResolver.resolveImportURI(modulePath, document)
 			if (uri) {
 				uris.push(uri)
 			}
@@ -57,11 +57,11 @@ export namespace ModuleResolver {
 
 	/** Resolve `import '....css'`. */
 	function* resolveNonNamedImportedPaths(text: string): Iterable<string> {
-		let re = /import\s+['"`](.+?)['"`]/g
+		const re = /import\s+['"`](.+?)['"`]/g
 		let match: RegExpExecArray | null
 
-		while (match = re.exec(text)) {
-			let path = match[1]
+		while ((match = re.exec(text)) !== null) {
+			const path = match[1]
 
 			if (isCSSLikePath(path)) {
 				yield path

--- a/server/src/languages/resolver/path.ts
+++ b/server/src/languages/resolver/path.ts
@@ -12,7 +12,7 @@ export namespace PathResolver {
 
 	/** Resolve relative path, will search `node_modules` directory to find final import path. */
 	export async function resolveModulePath(fromPath: string, toPath: string): Promise<string | null> {
-		let isModulePath = toPath.startsWith('~')
+		const isModulePath = toPath.startsWith('~')
 		let fromDir = path.dirname(fromPath)
 		let beModuleImport = false
 
@@ -27,7 +27,7 @@ export namespace PathResolver {
 			toPath = fixPathExtension(toPath, fromPath)
 
 			// Import relative path.
-			let filePath = path.resolve(fromDir, toPath)
+			const filePath = path.resolve(fromDir, toPath)
 			if (await fs.pathExists(filePath) && (await fs.stat(filePath)).isFile()) {
 				return filePath
 			}
@@ -41,12 +41,12 @@ export namespace PathResolver {
 
 		if (beModuleImport) {
 			while (fromDir) {
-				let filePath = path.resolve(fromDir, toPath)
+				const filePath = path.resolve(fromDir, toPath)
 				if (await fs.pathExists(filePath) && (await fs.stat(filePath)).isFile()) {
 					return filePath
 				}
 				
-				let dir = path.dirname(fromDir)
+				const dir = path.dirname(fromDir)
 				if (dir === fromDir) {
 					break
 				}
@@ -61,7 +61,7 @@ export namespace PathResolver {
 
 	/** Fix imported path with extension. */
 	function fixPathExtension(toPath: string, fromPath: string): string {
-		let fromPathExtension = getPathExtension(fromPath)
+		const fromPathExtension = getPathExtension(fromPath)
 
 		if (fromPathExtension === 'scss') {
 
@@ -88,14 +88,14 @@ export namespace PathResolver {
 	 * `part` must be in `Import` type.
 	 */
 	export async function resolveImportLocationLink(part: Part, fromDocument: TextDocument): Promise<LocationLink | null> {
-		let uri = await resolveImportURI(part.escapedText, fromDocument)
+		const uri = await resolveImportURI(part.escapedText, fromDocument)
 		if (!uri) {
 			return null
 		}
 
-		let targetRange = Range.create(0, 0, 0, 0)
-		let selectionRange = targetRange
-		let fromRange = PartConvertor.toRange(part, fromDocument)
+		const targetRange = Range.create(0, 0, 0, 0)
+		const selectionRange = targetRange
+		const fromRange = PartConvertor.toRange(part, fromDocument)
 
 		return LocationLink.create(uri, targetRange, selectionRange, fromRange)
 	}
@@ -103,15 +103,15 @@ export namespace PathResolver {
 	
 	/** Resolve import path to full uri. */
 	export async function resolveImportURI(importPath: string, fromDocument: TextDocument): Promise<string | null> {
-		let importProtocol = isRelativePath(importPath) ? '' : URI.parse(importPath).scheme
+		const importProtocol = isRelativePath(importPath) ? '' : URI.parse(importPath).scheme
 		if (importProtocol) {
 			return importPath
 		}
 
 		// File relative, try handle module path.
-		let fromURI = URI.parse(fromDocument.uri)
+		const fromURI = URI.parse(fromDocument.uri)
 		if (fromURI.scheme === 'file') {
-			let fullPath = await resolveModulePath(fromURI.fsPath, importPath)
+			const fullPath = await resolveModulePath(fromURI.fsPath, importPath)
 			if (!fullPath) {
 				return null
 			}

--- a/server/src/languages/scanners/any.ts
+++ b/server/src/languages/scanners/any.ts
@@ -57,6 +57,7 @@ export class AnyTokenScanner<T extends number> {
 	}
 
 	protected isEnded(): boolean {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- `state` is a number holding polymorphic per-scanner state enum values
 		return this.state === ScanState.EOF
 	}
 
@@ -84,7 +85,7 @@ export class AnyTokenScanner<T extends number> {
 		let readSome = false
 
 		while (true) {
-			let m = re.exec(this.string)
+			const m = re.exec(this.string)
 			if (!m) {
 				break
 			}
@@ -110,7 +111,7 @@ export class AnyTokenScanner<T extends number> {
 	 */
 	protected readUntilToMatch(re: RegExp): RegExpExecArray | null {
 		re.lastIndex = this.offset
-		let m = re.exec(this.string)
+		const m = re.exec(this.string)
 
 		if (m) {
 			this.offset = m.index
@@ -129,7 +130,7 @@ export class AnyTokenScanner<T extends number> {
 	 */
 	protected readOutToMatch(re: RegExp): RegExpExecArray | null {
 		re.lastIndex = this.offset
-		let m = re.exec(this.string)
+		const m = re.exec(this.string)
 
 		if (m) {
 			this.offset = m.index + m[0].length
@@ -147,7 +148,7 @@ export class AnyTokenScanner<T extends number> {
 	 * Cursor must before first quote `|"`.
 	 */
 	protected readString(): boolean {
-		let quote = this.peekChar()
+		const quote = this.peekChar()
 
 		// Avoid read start quote.
 		this.offset += 1
@@ -159,7 +160,7 @@ export class AnyTokenScanner<T extends number> {
 				break
 			}
 
-			let char = this.peekChar(-1)
+			const char = this.peekChar(-1)
 			
 			if (char === quote) {
 				break
@@ -178,7 +179,7 @@ export class AnyTokenScanner<T extends number> {
 			}
 		}
 
-		return this.state !== ScanState.EOF
+		return !this.isEnded()
 	}
 
 	/** Read all whitespaces, move cursor to before first non white space. */
@@ -220,16 +221,16 @@ export class AnyTokenScanner<T extends number> {
 	 * Supported language js, css, sass, less.
 	 */
 	protected readBracketed(): boolean {
-		let stack: string[] = []
+		const stack: string[] = []
 		let expect: string | null = null
-		let re = /[()\[\]{}"'`\/]/g
+		const re = /[()\[\]{}"'`\/]/g
 
-		while (this.state !== ScanState.EOF) {
+		while (!this.isEnded()) {
 			if (!this.readUntilToMatch(re)) {
 				break
 			}
 			
-			let char = this.peekChar()
+			const char = this.peekChar()
 
 			// `|"..."`
 			if (char === '"' || char === '\'') {
@@ -279,7 +280,6 @@ export class AnyTokenScanner<T extends number> {
 					expect = stack.pop()!
 				}
 				else {
-					expect = null
 					break
 				}
 			}
@@ -292,12 +292,12 @@ export class AnyTokenScanner<T extends number> {
 			}
 		}
 
-		return this.state !== ScanState.EOF
+		return !this.isEnded()
 	}
 
 	/** Read `...`, must ensure the current char is `|``. */
 	protected readTemplateLiteral(): boolean {
-		let re = /[`\\$]/g
+		const re = /[`\\$]/g
 
 		// Avoid read start quote.
 		this.offset += 1
@@ -307,7 +307,7 @@ export class AnyTokenScanner<T extends number> {
 				break
 			}
 
-			let char = this.peekChar(-1)
+			const char = this.peekChar(-1)
 			
 			if (char === '`') {
 				break
@@ -325,7 +325,7 @@ export class AnyTokenScanner<T extends number> {
 			}
 		}
 
-		return this.state !== ScanState.EOF
+		return !this.isEnded()
 	}
 
 	/** 
@@ -335,7 +335,7 @@ export class AnyTokenScanner<T extends number> {
 	 */
 	protected tryReadRegExp(): boolean {
 		let withinCharList = false
-		let startOffset = this.offset
+		const startOffset = this.offset
 
 		// Move cursor to `/|`
 		this.offset += 1
@@ -346,7 +346,7 @@ export class AnyTokenScanner<T extends number> {
 				return false
 			}
 
-			let char = this.peekChar(-1)
+			const char = this.peekChar(-1)
 			
 			// `\|.`, skip next char, even within character list.
 			if (char === '\\') {
@@ -381,7 +381,7 @@ export class AnyTokenScanner<T extends number> {
 		}
 
 		// Skip regexp flags.
-		!!this.readUntilToMatch(/[^a-z]/g)
+		this.readUntilToMatch(/[^a-z]/g)
 
 		return true
 	}
@@ -391,10 +391,10 @@ export class AnyTokenScanner<T extends number> {
 	 * Can only search one character each time.
 	 */
 	protected backSearchChar(from: number, match: RegExp, maxCount: number = Infinity): number {
-		let until = Math.max(from - maxCount, 0)
+		const until = Math.max(from - maxCount, 0)
 
 		for (let i = from; i >= until; i--) {
-			let char = this.string[i]
+			const char = this.string[i]
 			if (match.test(char)) {
 				return i
 			}
@@ -405,9 +405,9 @@ export class AnyTokenScanner<T extends number> {
 
 	/** Note it will sync start to offset. */
 	protected makeToken(type: T, startOffset: number = 0, endOffset: number = 0): AnyToken<T> {
-		let start = this.start + startOffset
-		let end = this.offset + endOffset
-		let text = this.string.slice(start, end)
+		const start = this.start + startOffset
+		const end = this.offset + endOffset
+		const text = this.string.slice(start, end)
 
 		this.sync()
 

--- a/server/src/languages/scanners/css-class-in-expression.ts
+++ b/server/src/languages/scanners/css-class-in-expression.ts
@@ -117,7 +117,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 					break
 				}
 
-				let char = this.peekChar()
+				const char = this.peekChar()
 
 				// `|${`
 				if (char === '$' && this.peekChar(1) === '{' && LanguageIds.isScriptSyntax(this.languageId)) {
@@ -152,7 +152,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 					break
 				}
 
-				let char = this.peekChar()
+				const char = this.peekChar()
 
 				// `|${`
 				if (char === '$') {
@@ -223,7 +223,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 					break
 				}
 
-				let char = this.peekChar()
+				const char = this.peekChar()
 
 				// `|'` or `|"` or `|``
 				if (char === '\'' || char === '"' || char === '`') {
@@ -270,7 +270,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 				// `abc|`
 				this.readUntilNot(/\w/g)
 
-				let nameToken = this.makeToken(CSSClassInExpressionTokenType.ReactModuleName)
+				const nameToken = this.makeToken(CSSClassInExpressionTokenType.ReactModuleName)
 
 				if (!this.readWhiteSpaces()) {
 					break
@@ -284,7 +284,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 					this.sync()
 
 					this.readUntilNot(/\w/g)
-					let propertyToken = this.makeToken(CSSClassInExpressionTokenType.ReactModuleProperty)
+					const propertyToken = this.makeToken(CSSClassInExpressionTokenType.ReactModuleProperty)
 
 					if (propertyToken.text.length > 0) {
 						yield nameToken
@@ -310,7 +310,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 							return
 						}
 
-						let propertyToken = this.makeToken(CSSClassInExpressionTokenType.ReactModuleProperty, 1, -1)
+						const propertyToken = this.makeToken(CSSClassInExpressionTokenType.ReactModuleProperty, 1, -1)
 
 						if (propertyToken.text.length > 0) {
 							yield nameToken
@@ -354,7 +354,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 						break
 					}
 
-					let propertyToken = this.makeToken(CSSClassInExpressionTokenType.ClassName, 1, -1)
+					const propertyToken = this.makeToken(CSSClassInExpressionTokenType.ClassName, 1, -1)
 					if (!this.readWhiteSpaces()) {
 						break
 					}
@@ -373,7 +373,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 					// `abc|`
 					this.readUntilNot(/\w/g)
 
-					let propertyToken = this.makeToken(CSSClassInExpressionTokenType.ClassName)
+					const propertyToken = this.makeToken(CSSClassInExpressionTokenType.ClassName)
 					if (!this.readWhiteSpaces()) {
 						break
 					}
@@ -416,7 +416,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 					break
 				}
 
-				let char = this.peekChar()
+				const char = this.peekChar()
 
 				// `|'...':`
 				if (char === '\'' || char === '"' || char === '`') {
@@ -463,7 +463,7 @@ export class CSSClassInExpressionTokenScanner extends AnyTokenScanner<CSSClassIn
 		}
 
 		// Skip `abc${...}`
-		let char = this.peekChar()
+		const char = this.peekChar()
 		if (char === '$') {
 
 			// Move to `$|`

--- a/server/src/languages/scanners/css-sass-indented.ts
+++ b/server/src/languages/scanners/css-sass-indented.ts
@@ -24,7 +24,7 @@ export class SassIndentedTokenScanner extends AnyTokenScanner<CSSTokenType> {
 	 */
 	*parseToTokens(start: number = 0): Iterable<CSSToken> {
 		this.start = this.offset = start
-		let indentCountStack: number[] = []
+		const indentCountStack: number[] = []
 		let currentIndentCount = 0
 
 		while (this.state !== ScanState.EOF) {
@@ -122,8 +122,8 @@ export class SassIndentedTokenScanner extends AnyTokenScanner<CSSTokenType> {
 					break
 				}
 
-				let indentText = this.peekText()
-				let indentCount = this.checkIndentCount(indentText)
+				const indentText = this.peekText()
+				const indentCount = this.checkIndentCount(indentText)
 				this.sync()
 
 				// |.class1
@@ -205,7 +205,7 @@ export class SassIndentedTokenScanner extends AnyTokenScanner<CSSTokenType> {
 	}
 
 	private checkIndentCount(text: string): number {
-		let re = /\t|  /g
+		const re = /\t| {2}/g
 		let count = 0
 
 		while (re.exec(text)) {

--- a/server/src/languages/scanners/css-selector.ts
+++ b/server/src/languages/scanners/css-selector.ts
@@ -92,11 +92,11 @@ export class CSSSelectorTokenScanner extends AnyTokenScanner<CSSSelectorTokenTyp
 
 	/** `.a, .b` -> `[.a, .b]`. */
 	parseToSeparatedTokens(): CSSSelectorToken[][] {
-		let tokens = this.parseToTokens()
-		let groups: CSSSelectorToken[][] = []
+		const tokens = this.parseToTokens()
+		const groups: CSSSelectorToken[][] = []
 
 		// Split by comma.
-		for (let token of tokens) {
+		for (const token of tokens) {
 			if (token.type === CSSSelectorTokenType.Comma) {
 				if (groups.length === 0 || groups[groups.length - 1].length > 0) {
 					groups.push([])
@@ -125,7 +125,7 @@ export class CSSSelectorTokenScanner extends AnyTokenScanner<CSSSelectorTokenTyp
 					break
 				}
 
-				let char = this.peekChar()
+				const char = this.peekChar()
 
 				// `|&`
 				if (char === '&') {

--- a/server/src/languages/scanners/html.ts
+++ b/server/src/languages/scanners/html.ts
@@ -206,8 +206,8 @@ export class HTMLTokenScanner extends AnyTokenScanner<HTMLTokenType> {
 		// `<abc|`
 		this.readUntilNot(IsTagName)
 
-		let tagName = this.peekText()
-		let lowerTagName = tagName.toLowerCase()
+		const tagName = this.peekText()
+		const lowerTagName = tagName.toLowerCase()
 		yield this.makeToken(HTMLTokenType.StartTagName)
 
 		if (lowerTagName === 'script' || lowerTagName === 'style') {
@@ -222,8 +222,8 @@ export class HTMLTokenScanner extends AnyTokenScanner<HTMLTokenType> {
 		// `</abc|>` or `</|>`
 		this.readUntilNot(IsTagName)
 
-		let tagName = this.peekText()
-		let lowerTagName = tagName.toLowerCase()
+		const tagName = this.peekText()
+		const lowerTagName = tagName.toLowerCase()
 
 		// Must end when `</style>` or `</script>`
 		if (this.endTagNameMustMatch && lowerTagName !== this.endTagNameMustMatch) {
@@ -250,7 +250,7 @@ export class HTMLTokenScanner extends AnyTokenScanner<HTMLTokenType> {
 		// Skip whitespaces.
 		this.readWhiteSpaces()
 
-		let char = this.peekChar()
+		const char = this.peekChar()
 
 		if (char === '>') {
 
@@ -321,7 +321,7 @@ export class HTMLTokenScanner extends AnyTokenScanner<HTMLTokenType> {
 	}
 
 	protected *onWithinAttributeValue(): Iterable<HTMLToken> {
-		let char = this.peekChar()
+		const char = this.peekChar()
 
 		// `=|"..."`
 		if (char === '"' || char === '\'') {
@@ -358,16 +358,16 @@ export class HTMLTokenScanner extends AnyTokenScanner<HTMLTokenType> {
 	 * brackets or quotes must appear in pairs.
 	 */
 	protected readExpressionLikeAttrValue() {
-		let stack: string[] = []
+		const stack: string[] = []
 		let expect: string | null = null
-		let re = /[()\[\]{}"'`\/\s>]/g
+		const re = /[()\[\]{}"'`\/\s>]/g
 
 		while (this.state !== ScanState.EOF) {
 			if (!this.readUntilToMatch(re)) {
 				return
 			}
 			
-			let char = this.peekChar()
+			const char = this.peekChar()
 
 			// Only difference with `readBracketed`.
 			if (!expect && /[\s>]/.test(char)) {
@@ -458,12 +458,12 @@ export class WhiteListHTMLTokenScanner extends HTMLTokenScanner {
 		// Normally when parsing jsx or tsx, when meet `<` and expect an expression,
 		// it recognizes as React Element.
 
-		let scanner = new HTMLTokenScanner(this.string, 0, this.languageId)
-		let startTags: Set<string> = new Set()
-		let whiteList: Set<string> = new Set()
+		const scanner = new HTMLTokenScanner(this.string, 0, this.languageId)
+		const startTags: Set<string> = new Set()
+		const whiteList: Set<string> = new Set()
 		let currentTagName: string | null = null
 
-		for (let token of scanner.parseToTokens()) {
+		for (const token of scanner.parseToTokens()) {
 			if (token.type !== HTMLTokenType.StartTagName
 				&& token.type !== HTMLTokenType.EndTagName
 				&& token.type !== HTMLTokenType.SelfCloseTagEnd
@@ -471,7 +471,7 @@ export class WhiteListHTMLTokenScanner extends HTMLTokenScanner {
 				continue
 			}
 	
-			let tagName: string = token.type === HTMLTokenType.SelfCloseTagEnd ? currentTagName! : token.text
+			const tagName: string = token.type === HTMLTokenType.SelfCloseTagEnd ? currentTagName! : token.text
 
 			if (DOMElementNames.has(tagName)) {
 				whiteList.add(tagName)
@@ -500,7 +500,7 @@ export class WhiteListHTMLTokenScanner extends HTMLTokenScanner {
 		this.readUntilNot(IsTagName)
 		
 
-		let tagName = this.peekText()
+		const tagName = this.peekText()
 
 		// If not in white list.
 		if (!this.whiteList.has(tagName)) {
@@ -522,7 +522,7 @@ export class WhiteListHTMLTokenScanner extends HTMLTokenScanner {
 		// `</abc|>` or `</|>`
 		this.readUntilNot(IsTagName)
 
-		let tagName = this.peekText()
+		const tagName = this.peekText()
 
 		if (!this.whiteList.has(tagName)) {
 			this.state = ScanState.AnyContent

--- a/server/src/languages/scanners/js.ts
+++ b/server/src/languages/scanners/js.ts
@@ -61,7 +61,7 @@ export class JSTokenScanner extends AnyTokenScanner<JSTokenType> {
 			return
 		}
 
-		let char = this.peekChar()
+		const char = this.peekChar()
 
 		// `|//`
 		if (char === '/' && this.peekChar(1) === '/') {
@@ -99,6 +99,7 @@ export class JSTokenScanner extends AnyTokenScanner<JSTokenType> {
 		}
 	}
 
+	// eslint-disable-next-line require-yield -- uniform scanner state method; this state emits no tokens
 	protected *onWithinSingleLineComment(): Iterable<JSToken> {
 
 		// `|\n`
@@ -111,6 +112,7 @@ export class JSTokenScanner extends AnyTokenScanner<JSTokenType> {
 		this.state = ScanState.AnyContent
 	}
 
+	// eslint-disable-next-line require-yield -- uniform scanner state method; this state emits no tokens
 	protected *onWithinMultiLineComment(): Iterable<JSToken> {
 
 		// `|*/`
@@ -134,10 +136,10 @@ export class JSTokenScanner extends AnyTokenScanner<JSTokenType> {
 
 	protected *mayMakeTemplateLiteralToken(): Iterable<JSToken> {
 		let templateTagName = ''
-		let nonWhiteSpacesOffset = this.backSearchChar(this.offset - 1, /\S/g)
+		const nonWhiteSpacesOffset = this.backSearchChar(this.offset - 1, /\S/g)
 
 		if (nonWhiteSpacesOffset > -1) {
-			let nameStartOffset = this.backSearchChar(nonWhiteSpacesOffset, /[^\w]/g)
+			const nameStartOffset = this.backSearchChar(nonWhiteSpacesOffset, /[^\w]/g)
 			templateTagName = this.string.slice(nameStartOffset + 1, nonWhiteSpacesOffset + 1)
 		}
 

--- a/server/src/languages/services/base-service-map.ts
+++ b/server/src/languages/services/base-service-map.ts
@@ -44,9 +44,10 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 		this.serviceMap.clear()
 	}
 
+	// eslint-disable-next-line @typescript-eslint/require-await -- overrides FileTracker.parseDocument, whose contract returns a Promise
 	protected async parseDocument(uri: string, document: TextDocument) {
 		try {
-			let service = this.createService(document)
+			const service = this.createService(document)
 			this.serviceMap.set(uri, service)
 		}
 		catch (err) {
@@ -56,7 +57,7 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	}
 
 	protected *walkAvailableServices(): IterableIterator<S> {
-		for (let uri of this.trackingMap.walkActiveURIs()) {
+		for (const uri of this.trackingMap.walkActiveURIs()) {
 			if (this.serviceMap.has(uri)) {
 				this.trackingMap.setUseTime(uri, this.timestamp)
 				yield this.serviceMap.get(uri)!
@@ -77,13 +78,13 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 
 	/** Force get a service by document, create it and cache as opened document. */
 	async forceGetServiceByDocument(document: TextDocument): Promise<S | undefined> {
-		let uri = document.uri
+		const uri = document.uri
 
 		if (!this.trackingMap.has(uri)) {
 			this.trackOpenedDocument(document)
 		}
 
-		return this.getFreshly(uri) as Promise<S | undefined>
+		return this.getFreshly(uri)
 	}
 
 	/** Force get a service by uri, create it but not cache. */
@@ -95,7 +96,7 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 		}
 
 		// Already included.
-		return this.getFreshly(uri) as Promise<S | undefined>
+		return this.getFreshly(uri)
 	}
 
 	/** Parse document to CSS service. */
@@ -104,9 +105,9 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async findDefinitions(matchPart: Part, fromPart: Part, fromDocument: TextDocument): Promise<LocationLink[]> {
 		await this.beFresh()
 
-		let locations: LocationLink[] = []
+		const locations: LocationLink[] = []
 
-		for (let service of this.walkAvailableServices()) {
+		for (const service of this.walkAvailableServices()) {
 			locations.push(...service.findDefinitions(matchPart, fromPart, fromDocument))
 		}
 
@@ -116,9 +117,9 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async findSymbols(query: string): Promise<SymbolInformation[]> {
 		await this.beFresh()
 
-		let symbols: SymbolInformation[] = []
+		const symbols: SymbolInformation[] = []
 
-		for (let service of this.walkAvailableServices()) {
+		for (const service of this.walkAvailableServices()) {
 			symbols.push(...service.findSymbols(query))
 		}
 
@@ -128,10 +129,10 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async getCompletionLabels(matchPart: Part, fromPart: Part, maxHoverStylePropertyCount: number): Promise<Map<string, CompletionLabel | null>> {
 		await this.beFresh()
 
-		let labelMap: Map<string, CompletionLabel | null> = new Map()
+		const labelMap: Map<string, CompletionLabel | null> = new Map()
 
-		for (let service of this.walkAvailableServices()) {
-			for (let [label, item] of service.getCompletionLabels(matchPart, fromPart, maxHoverStylePropertyCount)) {
+		for (const service of this.walkAvailableServices()) {
+			for (const [label, item] of service.getCompletionLabels(matchPart, fromPart, maxHoverStylePropertyCount)) {
 				labelMap.set(label, item)
 			}
 		}
@@ -148,10 +149,10 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async getReferencedCompletionLabels(fromPart: Part): Promise<Map<string, CompletionLabel | null>> {
 		await this.beFresh()
 
-		let labelMap: Map<string, CompletionLabel | null> = new Map()
+		const labelMap: Map<string, CompletionLabel | null> = new Map()
 
-		for (let service of this.walkAvailableServices()) {
-			for (let [label, detail] of service.getReferencedCompletionLabels(fromPart)) {
+		for (const service of this.walkAvailableServices()) {
+			for (const [label, detail] of service.getReferencedCompletionLabels(fromPart)) {
 				labelMap.set(label, detail)
 			}
 		}
@@ -162,9 +163,9 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async findReferences(matchDefPart: Part, fromPart: Part): Promise<Location[]> {
 		await this.beFresh()
 		
-		let locations: Location[] = []
+		const locations: Location[] = []
 
-		for (let htmlService of this.serviceMap.values()) {
+		for (const htmlService of this.serviceMap.values()) {
 			locations.push(...htmlService.findReferences(matchDefPart, fromPart))
 		}
 
@@ -174,8 +175,8 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async findHover(matchPart: Part, fromPart: Part, fromDocument: TextDocument, maxStylePropertyCount: number): Promise<Hover | null> {
 		await this.beFresh()
 
-		for (let service of this.walkAvailableServices()) {
-			let hover = service.findHover(matchPart, fromPart, fromDocument, maxStylePropertyCount)
+		for (const service of this.walkAvailableServices()) {
+			const hover = service.findHover(matchPart, fromPart, fromDocument, maxStylePropertyCount)
 			if (hover) {
 				return hover
 			}
@@ -188,10 +189,10 @@ export abstract class BaseServiceMap<S extends BaseService> extends FileTracker 
 	async getCSSVariables(names: Set<string>): Promise<Map<string, string>> {
 		await this.beFresh()
 
-		let map: Map<string, string> = new Map()
+		const map: Map<string, string> = new Map()
 
-		for (let service of this.walkAvailableServices()) {
-			for (let [name, value] of service.getCSSVariables(names)) {
+		for (const service of this.walkAvailableServices()) {
+			for (const [name, value] of service.getCSSVariables(names)) {
 				map.set(name, value)
 			}
 		}

--- a/server/src/languages/services/base-service.ts
+++ b/server/src/languages/services/base-service.ts
@@ -30,7 +30,7 @@ export abstract class BaseService {
 		this.document = document
 		this.config = config
 		
-		let tree = this.makeTree()
+		const tree = this.makeTree()
 		this.parts = [...tree.walkParts()]
 		this.partMap = groupBy(this.parts, part => [part.type, part])
 
@@ -39,7 +39,7 @@ export abstract class BaseService {
 	}
 
 	protected initAdditionalParts() {
-		let selectorParts = this.partMap.get(PartType.CSSSelectorWrapper) as CSSSelectorWrapperPart[] | undefined
+		const selectorParts = this.partMap.get(PartType.CSSSelectorWrapper) as CSSSelectorWrapperPart[] | undefined
 		if (!selectorParts) {
 			return
 		}
@@ -49,8 +49,8 @@ export abstract class BaseService {
 		this.partMap.set(PartType.CSSSelectorClass, [])
 		this.partMap.set(PartType.CSSSelectorId, [])
 
-		for (let part of selectorParts) {
-			for (let detail of part.details) {
+		for (const part of selectorParts) {
+			for (const detail of part.details) {
 				this.partMap.get(detail.type)!.push(detail)
 			}
 		}
@@ -61,22 +61,22 @@ export abstract class BaseService {
 			return
 		}
 
-		let classSelectorParts = this.partMap.get(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
+		const classSelectorParts = this.partMap.get(PartType.CSSSelectorClass) as CSSSelectorDetailedPart[] | undefined
 		if (classSelectorParts) {
-			for (let part of classSelectorParts) {
+			for (const part of classSelectorParts) {
 				if (part.escapedText === '&') {
 					continue
 				}
 				
-				for (let formatted of part.formatted) {
-					let className = formatted.slice(1)
+				for (const formatted of part.formatted) {
+					const className = formatted.slice(1)
 					this.definedClassNames.set(className, (this.definedClassNames.get(className) ?? 0) + 1)
 				}
 			}
 		}
 	}
 
-	protected abstract makeTree(): any
+	protected abstract makeTree(): {walkParts(): Iterable<Part>}
 
 	/** Get part list by part type. */
 	getPartsByType(type: PartType): Part[] {
@@ -91,17 +91,17 @@ export abstract class BaseService {
 			return this.resolvedImportedCSSURIs
 		}
 
-		let uris: string[] = []
+		const uris: string[] = []
 
-		for (let part of this.getPartsByType(PartType.CSSImportPath)) {
-			let protocol = isRelativePath(part.escapedText) ? '' : URI.parse(part.escapedText).scheme
+		for (const part of this.getPartsByType(PartType.CSSImportPath)) {
+			const protocol = isRelativePath(part.escapedText) ? '' : URI.parse(part.escapedText).scheme
 
 			// Relative path, or file, http or https.
 			if (protocol !== '' && protocol !== 'file' && protocol !== 'http' && protocol !== 'https') {
 				continue
 			}
 
-			let uri = await PathResolver.resolveImportURI(part.escapedText, this.document)
+			const uri = await PathResolver.resolveImportURI(part.escapedText, this.document)
 			if (uri) {
 				uris.push(uri)
 			}
@@ -130,7 +130,7 @@ export abstract class BaseService {
 	 * Note it never get detailed part.
 	 */
 	findPartAt(offset: number) {
-		let part = quickBinaryFindUpper(this.parts, (part) => {
+		const part = quickBinaryFindUpper(this.parts, (part) => {
 			if (part.start > offset) {
 				return 1
 			}
@@ -150,13 +150,13 @@ export abstract class BaseService {
 	 * Note if match a css selector part, it may return a selector detail part.
 	 */
 	findDetailedPartAt(offset: number): Part | undefined {
-		let part = this.findPartAt(offset)
+		const part = this.findPartAt(offset)
 
 		// Returns detail if in range.
 		if (part && part.type === PartType.CSSSelectorWrapper) {
-			let details = (part as CSSSelectorWrapperPart).details
+			const details = (part as CSSSelectorWrapperPart).details
 
-			for (let detail of details) {
+			for (const detail of details) {
 				if (detail
 					&& detail.start <= offset
 					&& detail.end >= offset
@@ -176,7 +176,7 @@ export abstract class BaseService {
 	 * Not it will not look up detailed parts.
 	 */
 	findPreviousPart(part: Part): Part | null {
-		let partIndex = quickBinaryFindIndex(this.parts, p => {
+		const partIndex = quickBinaryFindIndex(this.parts, p => {
 			return p.start - part.start
 		})
 
@@ -193,9 +193,9 @@ export abstract class BaseService {
 	 * `matchDefPart` must have been converted to definition type.
 	 */
 	findDefinitions(matchDefPart: Part, fromPart: Part, fromDocument: TextDocument): LocationLink[] {
-		let locations: LocationLink[] = []
+		const locations: LocationLink[] = []
 
-		for (let part of this.getPartsByType(matchDefPart.type)) {
+		for (const part of this.getPartsByType(matchDefPart.type)) {
 			if (!PartComparer.isMayFormattedListMatch(part, matchDefPart)) {
 				continue
 			}
@@ -226,10 +226,10 @@ export abstract class BaseService {
 	 * and may have more decorated selectors followed.
 	 */
 	findSymbols(query: string): SymbolInformation[] {
-		let symbols: SymbolInformation[] = []
-		let re = PartConvertor.makeWordStartsMatchExp(query)
+		const symbols: SymbolInformation[] = []
+		const re = PartConvertor.makeWordStartsMatchExp(query)
 
-		for (let part of this.parts) {
+		for (const part of this.parts) {
 
 			// Match text list with regexp, not match type.
 			if (!PartComparer.isMayFormattedListExpMatch(part, re)) {
@@ -247,10 +247,10 @@ export abstract class BaseService {
 	 * `matchDefPart` must have been converted to definition type.
 	 */
 	getCompletionLabels(matchPart: Part, fromPart: Part, maxStylePropertyCount: number): Map<string, CompletionLabel | null> {
-		let labelMap: Map<string, CompletionLabel | null> = new Map()
-		let re = PartConvertor.makeStartsMatchExp(matchPart.escapedText)
+		const labelMap: Map<string, CompletionLabel | null> = new Map()
+		const re = PartConvertor.makeStartsMatchExp(matchPart.escapedText)
 
-		for (let part of this.getPartsByType(matchPart.type)) {
+		for (const part of this.getPartsByType(matchPart.type)) {
 
 			// Now allow to complete itself.
 			if (part === fromPart) {
@@ -263,14 +263,14 @@ export abstract class BaseService {
 
 			// Show variable details.
 			if (part.type === PartType.CSSVariableDefinition) {
-				let labelText = (part as CSSVariableDefinitionPart).value
+				const labelText = (part as CSSVariableDefinitionPart).value
 				labelMap.set(part.escapedText, labelText ? {text: labelText, markdown: undefined} : null)
 			}
 			else {
 				let label: CompletionLabel | null = null
 
 				if (part.isSelectorDetailedType()) {
-					let wrapperPart = part.getWrapper(this)
+					const wrapperPart = part.getWrapper(this)
 					if (wrapperPart) {
 						label = {
 							text: wrapperPart.comment,
@@ -280,8 +280,8 @@ export abstract class BaseService {
 				}
 
 				// Convert text from current type to original type of text.
-				for (let text of PartComparer.mayFormatted(part)) {
-					let originalTypeOfText = PartConvertor.textToType(text, matchPart.type, fromPart.type)
+				for (const text of PartComparer.mayFormatted(part)) {
+					const originalTypeOfText = PartConvertor.textToType(text, matchPart.type, fromPart.type)
 					labelMap.set(originalTypeOfText, label)
 				}
 			}
@@ -297,18 +297,18 @@ export abstract class BaseService {
 	 * but current parts are reference types of parts.
 	 */
 	getReferencedCompletionLabels(fromPart: Part): Map<string, CompletionLabel | null> {
-		let labelMap: Map<string, CompletionLabel | null> = new Map()
-		let re = PartConvertor.makeIdentifiedStartsMatchExp(PartComparer.mayFormatted(fromPart), fromPart.type)
-		let matchDefPart = PartConvertor.toDefinitionMode(fromPart)
+		const labelMap: Map<string, CompletionLabel | null> = new Map()
+		const re = PartConvertor.makeIdentifiedStartsMatchExp(PartComparer.mayFormatted(fromPart), fromPart.type)
+		const matchDefPart = PartConvertor.toDefinitionMode(fromPart)
 
-		for (let type of this.partMap.keys()) {
+		for (const type of this.partMap.keys()) {
 
 			// Filter by type.
 			if (!PartComparer.isReferenceTypeMatch(type, matchDefPart.type)) {
 				continue
 			}
 
-			for (let part of this.getPartsByType(type)) {
+			for (const part of this.getPartsByType(type)) {
 
 				// Now allow to complete itself.
 				if (part === fromPart) {
@@ -320,10 +320,10 @@ export abstract class BaseService {
 					continue
 				}
 
-				for (let text of PartComparer.mayFormatted(part)) {
+				for (const text of PartComparer.mayFormatted(part)) {
 
 					// Replace back from `a-b` to `&-b`.
-					let mayNestedText = PartConvertor.textToType(text, part.type, fromPart.type).replace(re, fromPart.escapedText)
+					const mayNestedText = PartConvertor.textToType(text, part.type, fromPart.type).replace(re, fromPart.escapedText)
 
 					if (mayNestedText === text) {
 						labelMap.set(mayNestedText, null)
@@ -343,19 +343,19 @@ export abstract class BaseService {
 	 * `matchDefPart` must have been converted to definition type.
 	 */
 	findReferences(matchDefPart: Part, fromPart: Part): Location[] {
-		let locations: Location[] = []
+		const locations: Location[] = []
 
 		// Important, use may formatted text, and also must use definition text.
-		let texts = fromPart.hasFormattedList() ? PartComparer.mayFormatted(fromPart) : [matchDefPart.escapedText]
+		const texts = fromPart.hasFormattedList() ? PartComparer.mayFormatted(fromPart) : [matchDefPart.escapedText]
 
-		for (let type of this.partMap.keys()) {
+		for (const type of this.partMap.keys()) {
 
 			// Filter by type.
 			if (!PartComparer.isReferenceTypeMatch(type, matchDefPart.type)) {
 				continue
 			}
 
-			for (let part of this.getPartsByType(type)) {
+			for (const part of this.getPartsByType(type)) {
 
 				// No include from part.
 				// Beware this will cause some reference tests can't pass because of the build-in reference.
@@ -377,9 +377,9 @@ export abstract class BaseService {
 	
 	/** Find hover from CSS document for providing class or id name hover for a HTML document. */
 	findHover(matchDefPart: Part, fromPart: Part, fromDocument: TextDocument, maxStylePropertyCount: number): Hover | null {
-		let parts: Part[] = []
+		const parts: Part[] = []
 
-		for (let part of this.getPartsByType(matchDefPart.type)) {
+		for (const part of this.getPartsByType(matchDefPart.type)) {
 
 			// Not match non-primary detailed.
 			if (part.isSelectorDetailedType() && !part.primary) {
@@ -404,7 +404,7 @@ export abstract class BaseService {
 		}
 
 		if (part.isSelectorDetailedType()) {
-			let wrapperPart = part.getWrapper(this)
+			const wrapperPart = part.getWrapper(this)
 			if (!wrapperPart) {
 				return null
 			}
@@ -420,9 +420,9 @@ export abstract class BaseService {
 
 	/** Find all css variable values. */
 	getCSSVariables(names: Set<string>): Map<string, string> {
-		let map: Map<string, string> = new Map()
+		const map: Map<string, string> = new Map()
 
-		for (let part of this.getPartsByType(PartType.CSSVariableDefinition) as CSSVariableDefinitionPart[]) {
+		for (const part of this.getPartsByType(PartType.CSSVariableDefinition) as CSSVariableDefinitionPart[]) {
 			if (!names.has(part.escapedText)) {
 				continue
 			}

--- a/server/src/languages/services/css-service-map.ts
+++ b/server/src/languages/services/css-service-map.ts
@@ -17,8 +17,8 @@ export class CSSServiceMap extends BaseServiceMap<CSSService> {
 		if (this.config.enableClassNameDefinitionDiagnostic) {
 			this.definedClassNamesSet.clear()
 
-			for (let service of this.walkAvailableServices()) {
-				for (let [className, count] of service.getDefinedClassNames()) {
+			for (const service of this.walkAvailableServices()) {
+				for (const [className, count] of service.getDefinedClassNames()) {
 					this.definedClassNamesSet.set(className, (this.definedClassNamesSet.get(className) ?? 0) + count)
 				}
 			}
@@ -43,15 +43,15 @@ export class CSSServiceMap extends BaseServiceMap<CSSService> {
 	protected async parseDocument(uri: string, document: TextDocument) {
 		await super.parseDocument(uri, document)
 
-		let cssService = this.serviceMap.get(uri)
+		const cssService = this.serviceMap.get(uri)
 		if (!cssService) {
 			return
 		}
 
 		// If having `@import ...`, load it.
-		let importURIs = await cssService.getImportedCSSURIs()
+		const importURIs = await cssService.getImportedCSSURIs()
 
-		for (let importURI of importURIs) {
+		for (const importURI of importURIs) {
 			this.trackMoreURI(importURI)
 		}
 

--- a/server/src/languages/services/html-service-map.ts
+++ b/server/src/languages/services/html-service-map.ts
@@ -38,7 +38,7 @@ export class HTMLServiceMap extends BaseServiceMap<HTMLService> {
 		super.untrackURI(uri)
 
 		if (this.config.enableGlobalEmbeddedCSS) {
-			let oldImportURIs = this.cssImportMap.getByLeft(uri)
+			const oldImportURIs = this.cssImportMap.getByLeft(uri)
 			this.cssImportMap.deleteLeft(uri)
 
 			if (oldImportURIs) {
@@ -48,7 +48,7 @@ export class HTMLServiceMap extends BaseServiceMap<HTMLService> {
 	}
 
 	private checkImportURIsImported(importURIs: string[]) {
-		for (let importURI of importURIs) {
+		for (const importURI of importURIs) {
 
 			// Have no import to it from any html file.
 			if (this.cssImportMap.countOfRight(importURI) === 0) {
@@ -70,8 +70,8 @@ export class HTMLServiceMap extends BaseServiceMap<HTMLService> {
 		) {
 			this.definedClassNamesSet.clear()
 			
-			for (let service of this.walkAvailableServices()) {
-				for (let [className, count] of service.getDefinedClassNames()) {
+			for (const service of this.walkAvailableServices()) {
+				for (const [className, count] of service.getDefinedClassNames()) {
 					this.definedClassNamesSet.set(className, (this.definedClassNamesSet.get(className) ?? 0) + count)
 				}
 			}
@@ -80,8 +80,8 @@ export class HTMLServiceMap extends BaseServiceMap<HTMLService> {
 		if (this.config.enableClassNameReferenceDiagnostic) {
 			this.referencedClassNamesSet.clear()
 
-			for (let service of this.walkAvailableServices()) {
-				for (let [className, count] of service.getReferencedClassNamesSet()) {
+			for (const service of this.walkAvailableServices()) {
+				for (const [className, count] of service.getReferencedClassNamesSet()) {
 					this.referencedClassNamesSet.set(className, (this.referencedClassNamesSet.get(className) ?? 0) + count)
 				}
 			}
@@ -117,18 +117,18 @@ export class HTMLServiceMap extends BaseServiceMap<HTMLService> {
 		await super.parseDocument(uri, document)
 
 		if (this.config.enableGlobalEmbeddedCSS) {
-			let htmlService = this.serviceMap.get(uri)
+			const htmlService = this.serviceMap.get(uri)
 			if (!htmlService) {
 				return
 			}
 
-			let oldImportURIs = [...this.cssImportMap.getByLeft(uri) ?? []]
+			const oldImportURIs = [...this.cssImportMap.getByLeft(uri) ?? []]
 
 			// If having `@import ...`, load it.
-			let importURIs = await htmlService.getImportedCSSURIs()
+			const importURIs = await htmlService.getImportedCSSURIs()
 
 			// Force import css uris.
-			for (let importURI of importURIs) {
+			for (const importURI of importURIs) {
 				this.cssServiceMap.trackMoreURI(importURI, TrackingReasonMask.ForceImported)
 			}
 

--- a/server/src/languages/services/html-service.ts
+++ b/server/src/languages/services/html-service.ts
@@ -2,7 +2,7 @@ import {TextDocument} from 'vscode-languageserver-textdocument'
 import {PartType} from '../parts'
 import {HTMLTokenTree, JSTokenTree} from '../trees'
 import {BaseService} from './base-service'
-import path = require('node:path')
+import * as path from 'node:path'
 import {LanguageIds} from '../language-ids'
 
 
@@ -40,14 +40,14 @@ export class HTMLService extends BaseService {
 			return
 		}
 
-		let classTexts = [
+		const classTexts = [
 			...this.partMap.get(PartType.Class)?.map(p => p.escapedText) || [],
 			...this.partMap.get(PartType.ReactImportedCSSModuleProperty)?.map(p => p.escapedText) || [],
 			...this.partMap.get(PartType.CSSSelectorQueryClass)?.map(p => p.escapedText.slice(1)) || [],
 			...this.partMap.get(PartType.ReactDefaultImportedCSSModuleClass)?.map(p => p.escapedText) || [],
 		]
 
-		for (let text of classTexts) {
+		for (const text of classTexts) {
 			this.classNamesReferenceSet.set(text, (this.classNamesReferenceSet.get(text) ?? 0) + 1)
 		}
 	}
@@ -71,8 +71,8 @@ export class HTMLService extends BaseService {
 	}
 
 	protected makeTree() {
-		let extension = path.extname(this.document.uri).slice(1).toLowerCase()
-		let languageId = HTMLLanguageIdMap[this.document.languageId] ?? HTMLLanguageExtensionMap[extension] ?? 'html'
+		const extension = path.extname(this.document.uri).slice(1).toLowerCase()
+		const languageId = HTMLLanguageIdMap[this.document.languageId] ?? HTMLLanguageExtensionMap[extension] ?? 'html'
 		
 		if (LanguageIds.isHTMLSyntax(languageId)) {
 			return HTMLTokenTree.fromString(this.document.getText(), 0, languageId)

--- a/server/src/languages/trees/any-node.ts
+++ b/server/src/languages/trees/any-node.ts
@@ -28,7 +28,7 @@ export class AnyTokenNode<T extends AnyToken<number>> {
 			return null
 		}
 
-		let index = this.parent.children!.indexOf(this)
+		const index = this.parent.children!.indexOf(this)
 		if (index < this.parent.children!.length - 1) {
 			return this.parent.children![index + 1] as this
 		}
@@ -38,7 +38,7 @@ export class AnyTokenNode<T extends AnyToken<number>> {
 
 	/** Sort walking of parts. */
 	*sortParts(walk: Iterable<Part>): Iterable<Part> {
-		let list = [...walk]
+		const list = [...walk]
 		list.sort((a, b) => a.start - b.start)
 		yield* list
 	}
@@ -50,7 +50,7 @@ export class AnyTokenNode<T extends AnyToken<number>> {
 		}
 
 		if (this.children) {
-			for (let child of this.children) {
+			for (const child of this.children) {
 				yield* child.walk() as Iterable<this>
 			}
 		}
@@ -69,7 +69,7 @@ export class AnyTokenNode<T extends AnyToken<number>> {
 		}
 
 		if (this.children) {
-			for (let child of this.children) {
+			for (const child of this.children) {
 				yield* child.walk() as Iterable<this>
 			}
 		}

--- a/server/src/languages/trees/css-tree.ts
+++ b/server/src/languages/trees/css-tree.ts
@@ -25,13 +25,13 @@ export class CSSTokenTree extends CSSTokenNode {
 	
 	/** Make a CSS token tree by tokens. */
 	static fromTokens(tokens: Iterable<CSSToken>, string: string, tokenOffset: number, languageId: CSSLanguageId): CSSTokenTree {
-		let tree = new CSSTokenTree(string, tokenOffset, languageId)
+		const tree = new CSSTokenTree(string, tokenOffset, languageId)
 		let current: CSSTokenNode = tree
 		let latestComment: CSSToken | null = null
 		let notDetermined: CSSToken[] = []
 
 		function parseNotDetermined(mayBeSelector: boolean) {
-			let joint = joinTokens(notDetermined, string, tokenOffset)
+			const joint = joinTokens(notDetermined, string, tokenOffset)
 
 			if (isCommandToken(joint)) {
 				current.children!.push(new CSSTokenNode(CSSTokenNodeType.Command, joint, current))
@@ -47,7 +47,7 @@ export class CSSTokenTree extends CSSTokenNode {
 
 				// Not complete variable definition.
 				else if (/^\s*-/.test(joint.text)) {
-					let nameToken = parsePropertyNameToken(joint)!
+					const nameToken = parsePropertyNameToken(joint)!
 					current.children!.push(new CSSTokenNode(CSSTokenNodeType.PropertyName, nameToken, current, latestComment))
 				}
 
@@ -67,16 +67,16 @@ export class CSSTokenTree extends CSSTokenNode {
 		}
 
 		function parseAsPropertyDeclaration(token: CSSToken) {
-			let o = splitPropertyTokens(token)
+			const o = splitPropertyTokens(token)
 			if (o) {
-				let [restNameToken, nameToken, valueToken] = o
-				let nameNode = new CSSTokenNode(CSSTokenNodeType.PropertyName, nameToken, current, restNameToken ? null : latestComment)
-				let valueNode = new CSSTokenNode(CSSTokenNodeType.PropertyValue, valueToken, current)
+				const [restNameToken, nameToken, valueToken] = o
+				const nameNode = new CSSTokenNode(CSSTokenNodeType.PropertyName, nameToken, current, restNameToken ? null : latestComment)
+				const valueNode = new CSSTokenNode(CSSTokenNodeType.PropertyValue, valueToken, current)
 
 				nameNode.defEnd = valueToken.end
 
 				if (restNameToken) {
-					let restNameNode = new CSSTokenNode(CSSTokenNodeType.PropertyName, restNameToken, current, latestComment)
+					const restNameNode = new CSSTokenNode(CSSTokenNodeType.PropertyName, restNameToken, current, latestComment)
 					current.children!.push(restNameNode)
 				}
 
@@ -85,7 +85,7 @@ export class CSSTokenTree extends CSSTokenNode {
 		}
 
 
-		for (let token of tokens) {
+		for (const token of tokens) {
 			if (token.type === CSSTokenType.NotDetermined) {
 				notDetermined.push(token)
 			}
@@ -101,9 +101,9 @@ export class CSSTokenTree extends CSSTokenNode {
 
 			else if (token.type === CSSTokenType.ClosureStart) {
 				if (notDetermined.length > 0) {
-					let joint = joinTokens(notDetermined, string, tokenOffset)
-					let type = getSelectorLikeNodeType(joint, current)
-					let node: CSSTokenNode = new CSSTokenNode(type, joint, current, latestComment)
+					const joint = joinTokens(notDetermined, string, tokenOffset)
+					const type = getSelectorLikeNodeType(joint, current)
+					const node: CSSTokenNode = new CSSTokenNode(type, joint, current, latestComment)
 
 					current.children!.push(node)
 					current = node
@@ -165,9 +165,9 @@ export class CSSTokenTree extends CSSTokenNode {
 	 * Be static for the usage parsing inline style.
 	 */
 	static *parsePropertyValuePart(text: string, start: number): Iterable<Part> {
-		let varMatches = Picker.locateAllMatches(text, /var\(\s*([\w-]*)\s*\)|^\s*(-[\w-]*)|(--[\w-]*)/g, [0, 1])
+		const varMatches = Picker.locateAllMatches(text, /var\(\s*([\w-]*)\s*\)|^\s*(-[\w-]*)|(--[\w-]*)/g, [0, 1])
 
-		for (let match of varMatches) {
+		for (const match of varMatches) {
 
 			// `var()`, can't find captured match.
 			if (!match[1]) {
@@ -213,7 +213,7 @@ export class CSSTokenTree extends CSSTokenNode {
 	 * Note it ignores all non-primary selectors.
 	 */
 	*walkParts(): Iterable<Part> {
-		for (let node of this.walk()) {
+		for (const node of this.walk()) {
 			yield* this.parseNodePart(node)
 		}
 	}
@@ -244,16 +244,16 @@ export class CSSTokenTree extends CSSTokenNode {
 
 	/** For property name part. */
 	private *parsePropertyNamePart(node: CSSTokenNode): Iterable<Part> {
-		let text = node.token.text
+		const text = node.token.text
 		if (!text.startsWith('-')) {
 			return
 		}
 
-		let commentText = node.commentToken?.text
-		let nextNode = node.getNextSibling()
+		const commentText = node.commentToken?.text
+		const nextNode = node.getNextSibling()
 
 		// CSS Variable value.
-		let cssVariableValue = nextNode && nextNode.type === CSSTokenNodeType.PropertyValue
+		const cssVariableValue = nextNode && nextNode.type === CSSTokenNodeType.PropertyValue
 			? nextNode.token.text
 			: undefined
 
@@ -269,14 +269,14 @@ export class CSSTokenTree extends CSSTokenNode {
 
 	/** Parse a selector content to parts. */
 	private *parseSelectorString(text: string, start: number, node: CSSTokenNode, breaksSeparatorNesting: boolean): Iterable<Part> {
-		let groups = new CSSSelectorTokenScanner(text, start, this.languageId).parseToSeparatedTokens()
-		let parentParts = this.nodePartMap.get(node.parent!)
-		let commandWrapped = node.parent ? !!this.commandWrappedMap.get(node.parent) : false
+		const groups = new CSSSelectorTokenScanner(text, start, this.languageId).parseToSeparatedTokens()
+		const parentParts = this.nodePartMap.get(node.parent!)
+		const commandWrapped = node.parent ? !!this.commandWrappedMap.get(node.parent) : false
 
-		for (let group of groups) {
-			let joint = joinTokens(group, this.string, this.tokenOffset)
+		for (const group of groups) {
+			const joint = joinTokens(group, this.string, this.tokenOffset)
 
-			let part = CSSSelectorWrapperPart.parseFrom(
+			const part = CSSSelectorWrapperPart.parseFrom(
 				joint,
 				group,
 				parentParts,
@@ -297,7 +297,7 @@ export class CSSTokenTree extends CSSTokenNode {
 	
 	/** Parse a command string to parts. */
 	private *parseCommandPart(node: CSSTokenNode): Iterable<Part> {
-		let commandName = getCommandName(node.token.text)
+		const commandName = getCommandName(node.token.text)
 
 		// For workspace symbol searching.
 		if (commandName !== 'at-root') {
@@ -311,7 +311,7 @@ export class CSSTokenTree extends CSSTokenNode {
 			|| commandName === 'scope'
 			|| commandName === 'container'
 		) {
-			let parentParts = this.nodePartMap.get(node.parent!)
+			const parentParts = this.nodePartMap.get(node.parent!)
 			if (parentParts) {
 				this.nodePartMap.set(node, parentParts)
 			}
@@ -321,7 +321,7 @@ export class CSSTokenTree extends CSSTokenNode {
 
 			// `@import ''`.
 			// `class={style['class-name']}`.
-			let match = Picker.locateMatches(
+			const match = Picker.locateMatches(
 				node.token.text,
 				/@import\s+['"](.+?)['"]/,
 				[1]
@@ -335,7 +335,7 @@ export class CSSTokenTree extends CSSTokenNode {
 		else if (commandName === 'at-root') {
 
 			// `@at-root .class`.
-			let selectorMatch = Picker.locateMatches(
+			const selectorMatch = Picker.locateMatches(
 				node.token.text,
 				/@at-root\s+(.+)/,
 				[1]
@@ -384,15 +384,15 @@ function getSelectorLikeNodeType(token: CSSToken, current: CSSTokenNode): CSSTok
 function splitPropertyTokens(token: CSSToken): [CSSToken | null, CSSToken, CSSToken] | null {
 
 	// Here ignores comments.
-	let match = Picker.locateMatches(token.text, /([\w-]+)\s*:\s*(.+?)\s*$/, [1, 2])
+	const match = Picker.locateMatches(token.text, /([\w-]+)\s*:\s*(.+?)\s*$/, [1, 2])
 	if (!match) {
 		return null
 	}
 
 	// Name before property name.
 	let restName: CSSToken | null = null
-	let restText = token.text.slice(0, match[1].start)
-	let restNameMatch = Picker.locateMatches(restText, /[\w-]+/, [0])
+	const restText = token.text.slice(0, match[1].start)
+	const restNameMatch = Picker.locateMatches(restText, /[\w-]+/, [0])
 	if (restNameMatch) {
 		restName = {
 			type: CSSTokenType.NotDetermined,
@@ -402,14 +402,14 @@ function splitPropertyTokens(token: CSSToken): [CSSToken | null, CSSToken, CSSTo
 		}
 	}
 
-	let name: CSSToken = {
+	const name: CSSToken = {
 		type: CSSTokenType.NotDetermined,
 		text: match[1].text,
 		start: token.start + match[1].start,
 		end: token.start + match[1].start + match[1].text.length,
 	}
 
-	let value: CSSToken = {
+	const value: CSSToken = {
 		type: CSSTokenType.NotDetermined,
 		text: match[2].text,
 		start: token.start + match[2].start,
@@ -421,13 +421,13 @@ function splitPropertyTokens(token: CSSToken): [CSSToken | null, CSSToken, CSSTo
 
 
 function parsePropertyNameToken(token: CSSToken): CSSToken | null {
-	let match = Picker.locateMatches(token.text, /[\w-_]+/, [0])
+	const match = Picker.locateMatches(token.text, /[\w-_]+/, [0])
 	if (!match) {
 		return null
 	}
 
 	// Exclude whitespaces.
-	let name: CSSToken = {
+	const name: CSSToken = {
 		type: CSSTokenType.NotDetermined,
 		text: match[0].text,
 		start: token.start + match[0].start,

--- a/server/src/languages/trees/html-node.ts
+++ b/server/src/languages/trees/html-node.ts
@@ -29,7 +29,7 @@ export class HTMLTokenNode extends AnyTokenNode<HTMLToken> {
 
 	get firstTextNode(): HTMLTokenNode | null {
 		if (this.children && this.children.length > 0 && this.children[0].token.type === HTMLTokenType.Text) {
-			return this.children[0] as HTMLTokenNode
+			return this.children[0]
 		}
 
 		return null
@@ -57,7 +57,7 @@ export class HTMLTokenNode extends AnyTokenNode<HTMLToken> {
 			return null
 		}
 
-		let attr = this.attrs.find(attr => attr.name.text === name)
+		const attr = this.attrs.find(attr => attr.name.text === name)
 		if (attr && attr.value) {
 			return removeQuotesFromToken(attr.value)
 		}
@@ -68,7 +68,7 @@ export class HTMLTokenNode extends AnyTokenNode<HTMLToken> {
 	
 	/** Attribute value text, with quotes removed. */
 	getAttributeValue(name: string): string | null {
-		let attr = this.getAttribute(name)
+		const attr = this.getAttribute(name)
 		if (attr) {
 			return attr.text
 		}

--- a/server/src/languages/trees/html-tree.ts
+++ b/server/src/languages/trees/html-tree.ts
@@ -35,19 +35,19 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 	/** Make a HTML token tree by string. */
 	static fromString(string: string, scannerStart: number = 0, languageId: HTMLLanguageId = 'html'): HTMLTokenTree {
-		let tokens = new HTMLTokenScanner(string, scannerStart, languageId).parseToTokens()
+		const tokens = new HTMLTokenScanner(string, scannerStart, languageId).parseToTokens()
 		return HTMLTokenTree.fromTokens(tokens, languageId)
 	}
 
 	/** Make a token tree by tokens. */
 	static fromTokens(tokens: Iterable<HTMLToken>, languageId: HTMLLanguageId = 'html'): HTMLTokenTree {
-		let tree = new HTMLTokenTree(languageId)
+		const tree = new HTMLTokenTree(languageId)
 		let current: HTMLTokenNode = tree
 		let currentAttr: {name: HTMLToken, value: HTMLToken | null} | null = null
 
-		for (let token of tokens) {
+		for (const token of tokens) {
 			if (token.type === HTMLTokenType.StartTagName) {
-				let tagNode: HTMLTokenNode = new HTMLTokenNode(token, current)
+				const tagNode: HTMLTokenNode = new HTMLTokenNode(token, current)
 				current.children!.push(tagNode)
 				current = tagNode
 			}
@@ -99,12 +99,12 @@ export class HTMLTokenTree extends HTMLTokenNode {
 			}
 
 			else if (token.type === HTMLTokenType.Text) {
-				let textNode = new HTMLTokenNode(token, current)
+				const textNode = new HTMLTokenNode(token, current)
 				current.children!.push(textNode)
 			}
 
 			else if (token.type === HTMLTokenType.CommentText) {
-				let commentNode = new HTMLTokenNode(token, current)
+				const commentNode = new HTMLTokenNode(token, current)
 				current.children!.push(commentNode)
 			}
 		}
@@ -127,7 +127,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 	}
 
 	*walkParts(): Iterable<Part> {
-		for (let node of this.walk()) {
+		for (const node of this.walk()) {
 			yield* this.parseNodeParts(node)
 		}
 	}
@@ -135,7 +135,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 	/** Parse node and attributes. */
 	protected *parseNodeParts(node: HTMLTokenNode): Iterable<Part> {
 		if (node.token.type === HTMLTokenType.StartTagName) {
-			let partType = /^[A-Z]/.test(node.token.text) ? PartType.ComponentTag : PartType.Tag
+			const partType = /^[A-Z]/.test(node.token.text) ? PartType.ComponentTag : PartType.Tag
 			yield new Part(partType, node.token.text, node.token.start, node.tagLikeEnd)
 
 			// Parse attributes and sort them.
@@ -152,7 +152,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 	/** Parse attributes for parts. */
 	protected *parseAttrParts(node: HTMLTokenNode) {
-		for (let attr of node.attrs!) {
+		for (const attr of node.attrs!) {
 			yield* this.parseAttrPart(attr.name, attr.value)
 		}
 
@@ -161,8 +161,8 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 	/** For attribute part. */
 	protected *parseAttrPart(attrName: HTMLToken, attrValue: HTMLToken | null): Iterable<Part> {
-		let name = attrName.text
-		let unQuotedAttrValue = attrValue ? removeQuotesFromToken(attrValue) : null
+		const name = attrName.text
+		const unQuotedAttrValue = attrValue ? removeQuotesFromToken(attrValue) : null
 
 		if (name === 'id') {
 			if (unQuotedAttrValue) {
@@ -199,7 +199,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 				// Exclude template literal `class="${...}"`
 
 				// Which supports `"{className: boolean}"` syntax.
-				let alreadyAnExpression = name.endsWith('-bind:class')
+				const alreadyAnExpression = name.endsWith('-bind:class')
 					|| this.languageId === 'vue' && name === ':class'
 
 				let text = attrValue.text
@@ -219,8 +219,8 @@ export class HTMLTokenTree extends HTMLTokenNode {
 		else if (attrValue && name.startsWith('on') && isExpressionLike(attrValue.text)) {
 
 			// Start a white list HTML tree to parse for React Elements.
-			let tokens = new WhiteListHTMLTokenScanner(attrValue.text, attrValue.start, this.languageId).parseToTokens()
-			let htmlTree = HTMLTokenTree.fromTokens(tokens, this.languageId)
+			const tokens = new WhiteListHTMLTokenScanner(attrValue.text, attrValue.start, this.languageId).parseToTokens()
+			const htmlTree = HTMLTokenTree.fromTokens(tokens, this.languageId)
 			yield* htmlTree.walkParts()
 		}
 
@@ -235,7 +235,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 		// `var xxxClassNameXXX = `
 		else if (attrValue && isExpressionLike(attrValue.text)) {
-			for (let part of ClassNamesInJS.walkParts(attrValue.text, attrValue.start)) {
+			for (const part of ClassNamesInJS.walkParts(attrValue.text, attrValue.start)) {
 				yield part
 			}
 		}
@@ -252,8 +252,8 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 	/** Parse expression like. */
 	protected *parseExpressionLike(text: string, start: number, alreadyAnExpression: boolean): Iterable<Part> {
-		let scanner = new CSSClassInExpressionTokenScanner(text, start, this.languageId, alreadyAnExpression)
-		for (let token of scanner.parseToTokens()) {
+		const scanner = new CSSClassInExpressionTokenScanner(text, start, this.languageId, alreadyAnExpression)
+		for (const token of scanner.parseToTokens()) {
 			if (token.type === CSSClassInExpressionTokenType.ClassName) {
 				yield new Part(PartType.Class, token.text, token.start)
 			}
@@ -273,7 +273,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 	protected *parseImportPart(node: HTMLTokenNode): Iterable<Part> {
 		if (node.tagName === 'link') {
 			if (node.getAttributeValue('rel') === 'stylesheet') {
-				let href = node.getAttribute('href')
+				const href = node.getAttribute('href')
 				if (href) {
 					yield new Part(PartType.CSSImportPath, href.text, href.start)
 				}
@@ -282,7 +282,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 		// Vue.js only.
 		else if (node.tagName === 'style') {
-			let src = node.getAttribute('src')
+			const src = node.getAttribute('src')
 			if (src) {
 				yield new Part(PartType.CSSImportPath, src.text, src.start)
 			}
@@ -291,7 +291,7 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 	/** For react css module. */
 	protected *parseReactModulePart(attrValue: HTMLToken): Iterable<Part> {
-		let start = attrValue.start
+		const start = attrValue.start
 
 		// `class={...}`.
 		if (!/^\s*\{[\s\S]*?\}\s*$/.test(attrValue.text)) {
@@ -300,52 +300,52 @@ export class HTMLTokenTree extends HTMLTokenNode {
 
 		// `style.className`.
 		// `style['class-name']`.
-		let matches = Picker.locateAllMatchGroups(
+		const matches = Picker.locateAllMatchGroups(
 			attrValue.text,
 			/(?<moduleName>\w+)(?:\.(?<propertyName1>\w+)|\[\s*['"`](?<propertyName2>\w[\w-]*)['"`]\s*\])/g
 		)
 
-		for (let match of matches) {
+		for (const match of matches) {
 			yield new Part(PartType.ReactImportedCSSModuleName, match.moduleName.text, match.moduleName.start + start)
 
-			let propertyName = match.propertyName1 ?? match.propertyName2
+			const propertyName = match.propertyName1 ?? match.propertyName2
 			yield new Part(PartType.ReactImportedCSSModuleProperty, propertyName.text, propertyName.start + start)
 		}
 	}
 
 	/** Parse script tag for parts. */
 	protected *parseScriptPart(node: HTMLTokenNode): Iterable<Part> {
-		let textNode = node.firstTextNode
+		const textNode = node.firstTextNode
 
 		// Not process embedded js within embedded html.
 		if (textNode && textNode.token.text && LanguageIds.isHTMLSyntax(this.languageId)) {
-			let jsTree = JSTokenTree.fromString(textNode.token.text, textNode.token.start, 'js')
+			const jsTree = JSTokenTree.fromString(textNode.token.text, textNode.token.start, 'js')
 			yield* jsTree.walkParts()
 		}
 	}
 
 	/** Parse style tag for parts. */
 	protected *parseStylePart(node: HTMLTokenNode): Iterable<Part> {
-		let textNode = node.firstTextNode
+		const textNode = node.firstTextNode
 		if (textNode) {
-			let languageId = node.getAttributeValue('lang') ?? 'css'
+			const languageId = node.getAttributeValue('lang') ?? 'css'
 			yield* this.parseStyleTextParts(textNode.token.text, textNode.token.start, languageId as CSSLanguageId)
 		}
 	}
 
 	/** Parse style content for parts. */
 	protected *parseStyleTextParts(text: string, start: number, languageId: CSSLanguageId): Iterable<Part> {
-		let cssTree = CSSTokenTree.fromString(text, start, languageId)
+		const cssTree = CSSTokenTree.fromString(text, start, languageId)
 		yield* cssTree.walkParts()
 	}
 
 	/** Parse style property content for parts. */
 	protected *parseStylePropertyParts(text: string, start: number): Iterable<Part> {
-		let matches = Picker.locateAllMatches(text, /([\w-]+)\s*:\s*(.+?)\s*(?:;|$)/g, [1, 2])
+		const matches = Picker.locateAllMatches(text, /([\w-]+)\s*:\s*(.+?)\s*(?:;|$)/g, [1, 2])
 
-		for (let match of matches) {
-			let name = match[1]
-			let value = match[2]
+		for (const match of matches) {
+			const name = match[1]
+			const value = match[2]
 		
 			yield* CSSTokenTree.parsePropertyNamePart(name.text, name.start + start, undefined, value.text)
 			yield* CSSTokenTree.parsePropertyValuePart(value.text, value.start + start)

--- a/server/src/languages/trees/js-tree.ts
+++ b/server/src/languages/trees/js-tree.ts
@@ -13,21 +13,21 @@ export class JSTokenTree extends JSTokenNode {
 
 	/** Make a HTML token tree by string. */
 	static fromString(string: string, scannerStart: number = 0, languageId: HTMLLanguageId = 'js'): JSTokenTree {
-		let tokens = new JSTokenScanner(string, scannerStart, languageId).parseToTokens()
+		const tokens = new JSTokenScanner(string, scannerStart, languageId).parseToTokens()
 		return JSTokenTree.fromTokens(tokens, languageId)
 	}
 
 	/** Make a token tree by tokens. */
 	static fromTokens(tokens: Iterable<JSToken>, languageId: HTMLLanguageId = 'js'): JSTokenTree {
-		let tree = new JSTokenTree(languageId)
+		const tree = new JSTokenTree(languageId)
 
-		for (let token of tokens) {
+		for (const token of tokens) {
 			if (token.type === JSTokenType.HTML
 				|| token.type === JSTokenType.CSS
 				|| token.type === JSTokenType.Script
 			) {
-				let tagNode: JSTokenNode = new JSTokenNode(token, tree)
-				tree.children!.push(tagNode)
+				const tagNode: JSTokenNode = new JSTokenNode(token, tree)
+				tree.children.push(tagNode)
 			}
 		}
 
@@ -51,7 +51,7 @@ export class JSTokenTree extends JSTokenNode {
 	}
 
 	*walkParts(): Iterable<Part> {
-		for (let node of this.walk()) {
+		for (const node of this.walk()) {
 			yield* this.parseNodeParts(node)
 		}
 	}
@@ -73,20 +73,20 @@ export class JSTokenTree extends JSTokenNode {
 	protected *parseHTMLParts(node: JSTokenNode): Iterable<Part> {
 
 		// HTML tree accept current language, and it affects some actions.
-		let htmlTree = HTMLTokenTree.fromString(node.token.text, node.token.start, this.languageId)
+		const htmlTree = HTMLTokenTree.fromString(node.token.text, node.token.start, this.languageId)
 		yield* htmlTree.walkParts()
 	}
 
 	/** Parse css template part. */
 	protected *parseCSSParts(node: JSTokenNode): Iterable<Part> {
-		let cssTree = CSSTokenTree.fromString(node.token.text, node.token.start, 'css')
+		const cssTree = CSSTokenTree.fromString(node.token.text, node.token.start, 'css')
 		yield* cssTree.walkParts()
 	}
 
 	/** Parse script text for parts. */
 	protected *parseScriptParts(node: JSTokenNode): Iterable<Part> {
-		let text = node.token.text
-		let start = node.token.start
+		const text = node.token.text
+		const start = node.token.start
 
 		// `querySelect('.class-name')`
 	 	// `$('.class-name')`
@@ -96,12 +96,12 @@ export class JSTokenTree extends JSTokenNode {
 			[1]
 		)
 
-		for (let match of matches) {
-			let selector = match[1].text
-			let selectorStart = match[1].start + start
-			let tokens = new CSSSelectorTokenScanner(selector, selectorStart, 'css').parseToTokens()
+		for (const match of matches) {
+			const selector = match[1].text
+			const selectorStart = match[1].start + start
+			const tokens = new CSSSelectorTokenScanner(selector, selectorStart, 'css').parseToTokens()
 
-			for (let token of tokens) {
+			for (const token of tokens) {
 				if (token.type === CSSSelectorTokenType.Tag) {
 					yield new Part(PartType.CSSSelectorQueryTag, token.text, token.start)
 				}
@@ -122,13 +122,13 @@ export class JSTokenTree extends JSTokenNode {
 			[1]
 		)
 
-		for (let match of matches) {
+		for (const match of matches) {
 			yield (new Part(PartType.Class, match[1].text, match[1].start + start)).trim()
 		}
 
 
 		// `var xxxClassNameXXX = `
-		for (let part of ClassNamesInJS.walkParts(text, start)) {
+		for (const part of ClassNamesInJS.walkParts(text, start)) {
 			yield part
 		}
 
@@ -140,7 +140,7 @@ export class JSTokenTree extends JSTokenNode {
 			[1]
 		)
 
-		for (let match of matches) {
+		for (const match of matches) {
 			yield (new Part(PartType.CSSVariableAssignment, match[1].text, match[1].start + start)).trim()
 		}
 
@@ -154,8 +154,8 @@ export class JSTokenTree extends JSTokenNode {
 			[1]
 		)
 
-		for (let match of matches) {
-			let path = match[1].text
+		for (const match of matches) {
+			const path = match[1].text
 
 			if (isCSSLikePath(path)) {
 				yield (new Part(PartType.CSSImportPath, match[1].text, match[1].start + start)).trim()
@@ -171,12 +171,12 @@ export class JSTokenTree extends JSTokenNode {
 
 	/** Parse react elements. */
 	protected *parseReactElementParts(node: JSTokenNode): Iterable<Part> {
-		let text = node.token.text
-		let start = node.token.start
+		const text = node.token.text
+		const start = node.token.start
 
 		// Start a white list HTML tree to parse for React Elements.
-		let tokens = new WhiteListHTMLTokenScanner(text, start, this.languageId).parseToTokens()
-		let htmlTree = HTMLTokenTree.fromTokens(tokens, this.languageId)
+		const tokens = new WhiteListHTMLTokenScanner(text, start, this.languageId).parseToTokens()
+		const htmlTree = HTMLTokenTree.fromTokens(tokens, this.languageId)
 		yield* htmlTree.walkParts()
 	}
 }

--- a/server/src/languages/trees/picker.ts
+++ b/server/src/languages/trees/picker.ts
@@ -13,7 +13,7 @@ export namespace Picker {
 	 * `re` must not be global.
 	 */
 	export function locateMatches<I extends number>(text: string, re: RegExp, matchIndices: I[]): Record<I, Picked> | null {
-		let match = text.match(re)
+		const match = text.match(re)
 		if (!match) {
 			return null
 		}
@@ -31,7 +31,7 @@ export namespace Picker {
 	export function* locateAllMatches<I extends number>(text: string, re: RegExp, matchIndices: I[]): Iterable<Record<I, Picked>> {
 		let match: RegExpExecArray | null
 
-		while (match = re.exec(text)) {
+		while ((match = re.exec(text)) !== null) {
 			yield addOffsetToMatches(match, matchIndices)
 		}
 	}
@@ -42,7 +42,7 @@ export namespace Picker {
 	 * `re` must not be global.
 	 */
 	export function locateMatchGroups(text: string, re: RegExp): Record<string, Picked> | null {
-		let match = text.match(re)
+		const match = text.match(re)
 		if (!match) {
 			return null
 		}
@@ -58,7 +58,7 @@ export namespace Picker {
 	export function* locateAllMatchGroups(text: string, re: RegExp): Iterable<Record<string, Picked>> {
 		let match: RegExpExecArray | null
 
-		while (match = re.exec(text)) {
+		while ((match = re.exec(text)) !== null) {
 			yield addOffsetToMatchGroup(match)
 		}
 	}
@@ -68,16 +68,16 @@ export namespace Picker {
 	 * Note it may not 100% get correct result.
 	 */
 	function addOffsetToMatches(match: RegExpMatchArray | RegExpExecArray, matchIndices: number[]): Record<number, Picked> {
-		let o: Record<number, Picked> = {}
+		const o: Record<number, Picked> = {}
 		let lastIndex = 0
 
-		for (let matchIndex of matchIndices) {
-			let m = match[matchIndex]
+		for (const matchIndex of matchIndices) {
+			const m = match[matchIndex]
 			if (!m) {
 				continue
 			}
 			
-			let start = matchIndex === 0 ? 0 : match[0].indexOf(m, lastIndex)
+			const start = matchIndex === 0 ? 0 : match[0].indexOf(m, lastIndex)
 
 			o[matchIndex] = {
 				text: m,
@@ -98,21 +98,21 @@ export namespace Picker {
 	 * `re` must not be global.
 	 */
 	function addOffsetToMatchGroup(match: RegExpMatchArray | RegExpExecArray): Record<string, Picked> {
-		let o: Record<string, Picked> = {}
+		const o: Record<string, Picked> = {}
 
-		let groups = match.groups
+		const groups = match.groups
 		if (!groups) {
 			return o
 		}
 
 		let lastIndex = 0
 
-		for (let [k, m] of Object.entries(groups)) {
+		for (const [k, m] of Object.entries(groups)) {
 			if (!m) {
 				continue
 			}
 			
-			let start = match[0].indexOf(m, lastIndex)
+			const start = match[0].indexOf(m, lastIndex)
 
 			o[k] = {
 				text: m,

--- a/server/src/languages/trees/utils.ts
+++ b/server/src/languages/trees/utils.ts
@@ -48,15 +48,15 @@ export function isExpressionLike(value: string) {
 
 
 /** Join several tokens to one. */
-export function joinTokens<T extends AnyToken<any>>(tokens: T[], string: string, tokenOffset: number): T {
+export function joinTokens<T extends AnyToken<number>>(tokens: T[], string: string, tokenOffset: number): T {
 	if (tokens.length === 1) {
 		return tokens[0]
 	}
 	else {
-		let type = tokens[0].type
-		let start = tokens[0].start
-		let end = tokens[tokens.length - 1].end
-		let text = string.slice(start - tokenOffset, end - tokenOffset)
+		const type = tokens[0].type
+		const start = tokens[0].start
+		const end = tokens[tokens.length - 1].end
+		const text = string.slice(start - tokenOffset, end - tokenOffset)
 
 		return {
 			type,

--- a/server/src/languages/utils.ts
+++ b/server/src/languages/utils.ts
@@ -3,10 +3,10 @@
  * @param pairFn get key and value pair by it.
  */
 export function groupBy<T, K, V>(list: Iterable<T>, pairFn: (value: T) => [K, V]): Map<K, V[]> {
-	let map: Map<K, V[]> = new Map()
+	const map: Map<K, V[]> = new Map()
 
-	for (let item of list) {
-		let [key, value] = pairFn(item)
+	for (const item of list) {
+		const [key, value] = pairFn(item)
 
 		let group = map.get(key)
 		if (!group) {
@@ -33,7 +33,7 @@ export function quickBinaryFindIndex<T>(sortedList: ArrayLike<T>, fn: (v: T) => 
 		return -1
 	}
 
-	let firstResult = fn(sortedList[0])
+	const firstResult = fn(sortedList[0])
 
 	if (firstResult === 0) {
 		return 0
@@ -43,7 +43,7 @@ export function quickBinaryFindIndex<T>(sortedList: ArrayLike<T>, fn: (v: T) => 
 		return -1
 	}
 
-	let lastResult = fn(sortedList[sortedList.length - 1])
+	const lastResult = fn(sortedList[sortedList.length - 1])
 
 	if (lastResult === 0) {
 		return sortedList.length - 1
@@ -57,8 +57,8 @@ export function quickBinaryFindIndex<T>(sortedList: ArrayLike<T>, fn: (v: T) => 
 	let end = sortedList.length - 1
 
 	while (start + 1 < end) {
-		let center = Math.floor((end + start) / 2)
-		let result = fn(sortedList[center])
+		const center = Math.floor((end + start) / 2)
+		const result = fn(sortedList[center])
 
 		if (result === 0) {
 			return center

--- a/server/src/reference.ts
+++ b/server/src/reference.ts
@@ -13,18 +13,18 @@ export async function findReferences(
 	configuration: Configuration,
 	pureReference: boolean
 ): Promise<Location[] | null> {
-	let documentExtension = getPathExtension(document.uri)
-	let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-	let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+	const documentExtension = getPathExtension(document.uri)
+	const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+	const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 	let locations: Location[] | null = null
 
 	if (isHTMLFile) {
-		let currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
+		const currentHTMLService = await htmlServiceMap.forceGetServiceByDocument(document)
 		if (!currentHTMLService) {
 			return null
 		}
 
-		let fromPart = currentHTMLService.findDetailedPartAt(offset)
+		const fromPart = currentHTMLService.findDetailedPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -37,12 +37,12 @@ export async function findReferences(
 		locations = await findReferencesInHTML(fromPart, currentHTMLService, htmlServiceMap, cssServiceMap, configuration, pureReference)
 	}
 	else if (isCSSFile) {
-		let currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
+		const currentCSSService = await cssServiceMap.forceGetServiceByDocument(document)
 		if (!currentCSSService) {
 			return null
 		}
 
-		let fromPart = currentCSSService.findDetailedPartAt(offset)
+		const fromPart = currentCSSService.findDetailedPartAt(offset)
 		if (!fromPart) {
 			return null
 		}
@@ -63,8 +63,8 @@ async function findReferencesInHTML(
 	configuration: Configuration,
 	pureReference: boolean
 ): Promise<Location[] | null> {
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
-	let locations: Location[] = []
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
+	const locations: Location[] = []
 
 
 	if (pureReference) {
@@ -105,8 +105,8 @@ async function findReferencesInCSS(
 	cssServiceMap: CSSServiceMap,
 	pureReference: boolean
 ): Promise<Location[] | null> {
-	let matchPart = PartConvertor.toDefinitionMode(fromPart)
-	let locations: Location[] = []
+	const matchPart = PartConvertor.toDefinitionMode(fromPart)
+	const locations: Location[] = []
 
 
 	if (pureReference) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,7 +20,7 @@ import {
 	Diagnostic,
 	CodeLens,
 	CodeLensParams
-} from 'vscode-languageserver'
+} from 'vscode-languageserver/node'
 import {Position, TextDocument} from 'vscode-languageserver-textdocument'
 import {HTMLServiceMap, CSSServiceMap, ClassNamesInJS} from './languages'
 import {generateGlobPatternByExtensions, generateGlobPatternByPatterns, getPathExtension} from './utils'
@@ -146,10 +146,18 @@ connection.onInitialized(async () => {
 	}
 
 	if (configuration.enableCSSVariableColorPreview) {
-		connection.onDocumentColor(Logger.logQuerierExecutedTime(server.provideDocumentCSSVariableColors.bind(server), 'hover'))
+		connection.onDocumentColor(async (params) => {
+			try {
+				return await server.provideDocumentCSSVariableColors(params, Logger.getTimestamp())
+			}
+			catch (err) {
+				Logger.error(String(err))
+				return []
+			}
+		})
 
 		// Just ensure no error happens.
-		connection.onColorPresentation(() => null)
+		connection.onColorPresentation(() => [])
 	}
 })
 
@@ -378,17 +386,17 @@ class CSSNavigationServer {
 	}
 
 	/** Provide document css variable color service. */
-	async provideDocumentCSSVariableColors(params: DocumentColorParams, time: number): Promise<ColorInformation[] | null> {
+	async provideDocumentCSSVariableColors(params: DocumentColorParams, time: number): Promise<ColorInformation[]> {
 		this.updateTimestamp(time)
 
 		let documentIdentifier = params.textDocument
 		let document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
-			return null
+			return []
 		}
-	
-		return getCSSVariableColors(document, this.htmlServiceMap, this.cssServiceMap, configuration)
+
+		return (await getCSSVariableColors(document, this.htmlServiceMap, this.cssServiceMap, configuration)) ?? []
 	}
 
 	/** Diagnose class names for a changed document. */

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -36,9 +36,9 @@ import '../../client/out/types'
 import {GlobPathSharer} from './core/file-tracker/glob-path-sharer'
 
 
-let connection: Connection = createConnection(ProposedFeatures.all)
+const connection: Connection = createConnection(ProposedFeatures.all)
 let configuration: Configuration
-let documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument)
+const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument)
 let server: CSSNavigationServer
 
 
@@ -50,7 +50,7 @@ let server: CSSNavigationServer
 
 // Server side request handlers.
 connection.onRequest('definitions', async({uri, position}: {uri: string, position: Position}) => {
-	let document = documents.get(uri)
+	const document = documents.get(uri)
 	if (!document) {
 		return {
 			success: false,
@@ -66,7 +66,7 @@ connection.onRequest('definitions', async({uri, position}: {uri: string, positio
 
 // Server side request handlers.
 connection.onRequest('references', async({uri, position}: {uri: string, position: Position}) => {
-	let document = documents.get(uri)
+	const document = documents.get(uri)
 	if (!document) {
 		return {
 			success: false,
@@ -84,7 +84,7 @@ connection.onRequest('references', async({uri, position}: {uri: string, position
 
 // Do initializing.
 connection.onInitialize((params: InitializeParams) => {
-	let options: InitializationOptions = params.initializationOptions
+	const options = params.initializationOptions as InitializationOptions
 	configuration = options.configuration
 	server = new CSSNavigationServer(options)
 
@@ -96,7 +96,7 @@ connection.onInitialize((params: InitializeParams) => {
 
 	// Print error messages after unhandled rejection promise.
 	process.on('unhandledRejection', function(reason) {
-		Logger.warn("Unhandled Rejection: " + reason)
+		Logger.warn("Unhandled Rejection: " + String(reason))
 	})
 
 
@@ -120,7 +120,7 @@ connection.onInitialize((params: InitializeParams) => {
 })
 
 // Listening events.
-connection.onInitialized(async () => {
+connection.onInitialized(() => {
 	if (configuration.enableGoToDefinition) {
 		connection.onDefinition(Logger.logQuerierExecutedTime(server.provideDefinitions.bind(server), 'definition'))
 	}
@@ -177,14 +177,14 @@ class CSSNavigationServer {
 		this.options = options
 		ClassNamesInJS.initWildNames(configuration.jsClassNameReferenceNames)
 		
-		let startPath = options.workspaceFolderPath
+		const startPath = options.workspaceFolderPath
 		
-		let alwaysIncludeGlobPattern = configuration.alwaysIncludeGlobPatterns
+		const alwaysIncludeGlobPattern = configuration.alwaysIncludeGlobPatterns
 			? generateGlobPatternByPatterns(configuration.alwaysIncludeGlobPatterns)
 			: undefined
 
 		// Shared glob querying.
-		let alwaysIncludeGlobSharer = alwaysIncludeGlobPattern ? new GlobPathSharer(alwaysIncludeGlobPattern, startPath) : undefined
+		const alwaysIncludeGlobSharer = alwaysIncludeGlobPattern ? new GlobPathSharer(alwaysIncludeGlobPattern, startPath) : undefined
 
 		const maxFileCount = configuration.maxFileCount;
 
@@ -219,7 +219,7 @@ class CSSNavigationServer {
 		// All these events can't register for twice, or the first one will not work.
 
 		documents.onDidChangeContent(async (event: TextDocumentChangeEvent<TextDocument>) => {
-			let map = this.pickServiceMap(event.document)
+			const map = this.pickServiceMap(event.document)
 			map?.onDocumentOpenOrContentChanged(event.document)
 
 			// Update class name diagnostic results.
@@ -229,29 +229,29 @@ class CSSNavigationServer {
 		})
 
 		documents.onDidSave((event: TextDocumentChangeEvent<TextDocument>) => {
-			let map = this.pickServiceMap(event.document)
+			const map = this.pickServiceMap(event.document)
 			map?.onDocumentSaved(event.document)
 		})
 
 		documents.onDidClose((event: TextDocumentChangeEvent<TextDocument>) => {
-			let map = this.pickServiceMap(event.document)
+			const map = this.pickServiceMap(event.document)
 			map?.onDocumentClosed(event.document)
 			this.diagnosedVersionMap.delete(event.document.uri)
 		})
 
-		connection.onDidChangeWatchedFiles((params: any) => {
-			this.htmlServiceMap.onWatchedFileOrFolderChanged(params)
-			this.cssServiceMap.onWatchedFileOrFolderChanged(params)
+		connection.onDidChangeWatchedFiles((params) => {
+			void this.htmlServiceMap.onWatchedFileOrFolderChanged(params)
+			void this.cssServiceMap.onWatchedFileOrFolderChanged(params)
 		})
 
 		Logger.log(`📁 Server for workspace "${path.basename(this.options.workspaceFolderPath)}" started.`)
 	}
 
 	private pickServiceMap(document: TextDocument): HTMLServiceMap | CSSServiceMap | null {
-		let uri = document.uri
-		let documentExtension = getPathExtension(uri)
-		let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-		let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+		const uri = document.uri
+		const documentExtension = getPathExtension(uri)
+		const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+		const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 
 		if (isHTMLFile) {
 			return this.htmlServiceMap
@@ -266,13 +266,13 @@ class CSSNavigationServer {
 
 	/** Get definitions by document and position. */
 	async getDefinitions(document: TextDocument, position: Position): Promise<Location[] | null> {
-		let offset = document.offsetAt(position)
+		const offset = document.offsetAt(position)
 		return findDefinitions(document, offset, this.htmlServiceMap, this.cssServiceMap, configuration)
 	}
 
 	/** Get references by document and position. */
 	async getReferences(document: TextDocument, position: Position): Promise<Location[] | null> {
-		let offset = document.offsetAt(position)
+		const offset = document.offsetAt(position)
 		return findReferences(document, offset, this.htmlServiceMap, this.cssServiceMap, configuration, true)
 	}
 
@@ -285,15 +285,15 @@ class CSSNavigationServer {
 	async provideDefinitions(params: TextDocumentPositionParams, time: number): Promise<Location[] | null> {
 		this.updateTimestamp(time)
 
-		let documentIdentifier = params.textDocument
-		let document = documents.get(documentIdentifier.uri)
+		const documentIdentifier = params.textDocument
+		const document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
 			return null
 		}
 
-		let position = params.position
-		let offset = document.offsetAt(position)
+		const position = params.position
+		const offset = document.offsetAt(position)
 
 		return findDefinitions(document, offset, this.htmlServiceMap, this.cssServiceMap, configuration)
 	}
@@ -302,14 +302,14 @@ class CSSNavigationServer {
 	async provideSymbols(symbol: WorkspaceSymbolParams, time: number): Promise<SymbolInformation[] | null> {
 		this.updateTimestamp(time)
 
-		let query = symbol.query
+		const query = symbol.query
 
 		// Returns nothing if haven't inputted.
 		if (!query) {
 			return null
 		}
 
-		let symbols: SymbolInformation[] = []
+		const symbols: SymbolInformation[] = []
 		symbols.push(...await this.cssServiceMap.findSymbols(query))
 
 		if (configuration.enableGlobalEmbeddedCSS) {
@@ -323,16 +323,16 @@ class CSSNavigationServer {
 	async provideCompletionItems(params: TextDocumentPositionParams, time: number): Promise<CompletionItem[] | null> {
 		this.updateTimestamp(time)
 
-		let documentIdentifier = params.textDocument
-		let document = documents.get(documentIdentifier.uri)
+		const documentIdentifier = params.textDocument
+		const document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
 			return null
 		}
 
 		// HTML or CSS file.
-		let position = params.position
-		let offset = document.offsetAt(position)
+		const position = params.position
+		const offset = document.offsetAt(position)
 
 		return getCompletionItems(document, offset, this.htmlServiceMap, this.cssServiceMap, configuration)
 	}
@@ -341,15 +341,15 @@ class CSSNavigationServer {
 	async provideReferences(params: ReferenceParams, time: number): Promise<Location[] | null> {
 		this.updateTimestamp(time)
 
-		let documentIdentifier = params.textDocument
-		let document = documents.get(documentIdentifier.uri)
+		const documentIdentifier = params.textDocument
+		const document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
 			return null
 		}
 
-		let position = params.position
-		let offset = document.offsetAt(position)
+		const position = params.position
+		const offset = document.offsetAt(position)
 
 		return findReferences(document, offset, this.htmlServiceMap, this.cssServiceMap, configuration, false)
 	}
@@ -358,15 +358,15 @@ class CSSNavigationServer {
 	async provideHover(params: HoverParams, time: number): Promise<Hover | null> {
 		this.updateTimestamp(time)
 
-		let documentIdentifier = params.textDocument
-		let document = documents.get(documentIdentifier.uri)
+		const documentIdentifier = params.textDocument
+		const document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
 			return null
 		}
 
-		let position = params.position
-		let offset = document.offsetAt(position)
+		const position = params.position
+		const offset = document.offsetAt(position)
 		
 		return findHover(document, offset, this.htmlServiceMap, this.cssServiceMap, configuration)
 	}
@@ -375,8 +375,8 @@ class CSSNavigationServer {
 	async provideCodeLens(params: CodeLensParams, time: number): Promise<CodeLens[] | null> {
 		this.updateTimestamp(time)
 
-		let documentIdentifier = params.textDocument
-		let document = documents.get(documentIdentifier.uri)
+		const documentIdentifier = params.textDocument
+		const document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
 			return null
@@ -389,8 +389,8 @@ class CSSNavigationServer {
 	async provideDocumentCSSVariableColors(params: DocumentColorParams, time: number): Promise<ColorInformation[]> {
 		this.updateTimestamp(time)
 
-		let documentIdentifier = params.textDocument
-		let document = documents.get(documentIdentifier.uri)
+		const documentIdentifier = params.textDocument
+		const document = documents.get(documentIdentifier.uri)
 
 		if (!document) {
 			return []
@@ -401,25 +401,25 @@ class CSSNavigationServer {
 
 	/** Diagnose class names for a changed document. */
 	async diagnoseOpenedOrChanged(document: TextDocument) {
-		let documentExtension = getPathExtension(document.uri)
-		let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-		let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+		const documentExtension = getPathExtension(document.uri)
+		const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+		const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 
 		if (!isHTMLFile && !isCSSFile) {
 			return
 		}
 
-		let previousVersion = this.diagnosedVersionMap.get(document.uri)
-		let isChanged = previousVersion !== undefined && document.version > previousVersion
+		const previousVersion = this.diagnosedVersionMap.get(document.uri)
+		const isChanged = previousVersion !== undefined && document.version > previousVersion
 		let fileCount = 0
-		let sharedCSSFragments = configuration.enableGlobalEmbeddedCSS
+		const sharedCSSFragments = configuration.enableGlobalEmbeddedCSS
 
 		Logger.timeStart('diagnostic-of-' + document.uri)
 
 		try {
-			let diagnostics = await this.getClassNameDiagnostics(document)
+			const diagnostics = await this.getClassNameDiagnostics(document)
 			if (diagnostics) {
-				connection.sendDiagnostics({uri: document.uri, diagnostics})
+				void connection.sendDiagnostics({uri: document.uri, diagnostics})
 				fileCount++
 			}
 
@@ -444,18 +444,18 @@ class CSSNavigationServer {
 	private async diagnoseMoreOfType(type: 'html' | 'css' | 'any'): Promise<number> {
 		let fileCount = 0
 
-		for (let document of documents.all()) {
-			let documentExtension = getPathExtension(document.uri)
-			let isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
-			let isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
+		for (const document of documents.all()) {
+			const documentExtension = getPathExtension(document.uri)
+			const isHTMLFile = configuration.activeHTMLFileExtensions.includes(documentExtension)
+			const isCSSFile = configuration.activeCSSFileExtensions.includes(documentExtension)
 
 			if (type === 'html' && !isHTMLFile || type === 'css' && !isCSSFile) {
 				continue
 			}
 
-			let diagnostics = await this.getClassNameDiagnostics(document)
+			const diagnostics = await this.getClassNameDiagnostics(document)
 			if (diagnostics) {
-				connection.sendDiagnostics({uri: document.uri, diagnostics})
+				void connection.sendDiagnostics({uri: document.uri, diagnostics})
 				fileCount++
 			}
 		}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -32,7 +32,6 @@ import {findHover} from './hover'
 import {getCSSVariableColors} from './css-variable-color'
 import {getDiagnostics} from './diagnostic'
 import {getCodeLens} from './code-lens'
-import '../../client/out/types'
 import {GlobPathSharer} from './core/file-tracker/glob-path-sharer'
 
 
@@ -469,4 +468,3 @@ class CSSNavigationServer {
 		return getDiagnostics(document, this.htmlServiceMap, this.cssServiceMap, configuration)
 	}
 }
-

--- a/server/src/utils/color/color.ts
+++ b/server/src/utils/color/color.ts
@@ -26,10 +26,10 @@ export class Color {
 
 		// HTML color name.
 		else if (str in HTMLColorNames) {
-			let n = HTMLColorNames[str]
-			let r = (n & 0xff0000) >> 16
-			let g = (n & 0x00ff00) >> 8
-			let b = n & 0x0000ff
+			const n = HTMLColorNames[str]
+			const r = (n & 0xff0000) >> 16
+			const g = (n & 0x00ff00) >> 8
+			const b = n & 0x0000ff
 
 			rgba = {r, g, b, a: 1}
 		}
@@ -40,7 +40,7 @@ export class Color {
 		}
 
 		else {
-			let name = str.match(/^\w+/)?.[0]
+			const name = str.match(/^\w+/)?.[0]
 			if (!name) {
 				return null
 			}
@@ -52,7 +52,7 @@ export class Color {
 			
 			// hsl.
 			else if (name === 'hsl' || name === 'hsla') {
-				let hsla = parseHSLA(str)
+				const hsla = parseHSLA(str)
 				if (hsla) {
 					rgba = HSLA2RGBA(hsla)
 				}
@@ -60,7 +60,7 @@ export class Color {
 		}
 
 		if (rgba) {
-			let {r, g, b, a} = rgba
+			const {r, g, b, a} = rgba
 			return new Color(r, g, b, a)
 		}
 
@@ -72,8 +72,8 @@ export class Color {
 	 * H betweens `0~6`, SL betweens `0~1`.
 	 */
 	static fromHSL(h: number, s: number, l: number): Color {
-		let rgba = HSLA2RGBA({h, s, l, a: 1})
-		let {r, g, b, a} = rgba
+		const rgba = HSLA2RGBA({h, s, l, a: 1})
+		const {r, g, b, a} = rgba
 
 		return new Color(r, g, b, a)
 	}
@@ -83,8 +83,8 @@ export class Color {
 	 * H betweens `0~6`, SLA betweens `0~1`.
 	 */
 	static fromHSLA(h: number, s: number, l: number, a: number): Color {
-		let rgba = HSLA2RGBA({h, s, l, a})
-		let {r, g, b} = rgba
+		const rgba = HSLA2RGBA({h, s, l, a})
+		const {r, g, b} = rgba
 		
 		return new Color(r, g, b, a)
 	}
@@ -104,8 +104,8 @@ export class Color {
 			return improveColorString
 		}
 
-		let improveColor = Color.fromString(improveColorString)
-		let compareColor = Color.fromString(compareColorString)
+		const improveColor = Color.fromString(improveColorString)
+		const compareColor = Color.fromString(compareColorString)
 
 		if (!improveColor || !compareColor) {
 			return improveColorString
@@ -120,8 +120,8 @@ export class Color {
 			return true
 		}
 
-		let c1 = Color.fromString(color1)
-		let c2 = Color.fromString(color2)
+		const c1 = Color.fromString(color1)
+		const c2 = Color.fromString(color2)
 
 		if (!c1 || !c2) {
 			return false
@@ -152,15 +152,15 @@ export class Color {
 
 	/** Get `{h, s, l}` values, h betweens `0~6`, others betweens `0~1`. */
 	get hsl(): {h: number, s: number, l: number} {
-		let hsla = RGBA2HSLA(this)
-		let {h, s, l} = hsla
+		const hsla = RGBA2HSLA(this)
+		const {h, s, l} = hsla
 
 		return {h, s, l}
 	}
 
 	/** Get `{h, s, l, a}` values, h betweens `0~6`, others betweens `0~1`. */
 	get hsla(): {h: number, s: number, l: number, a: number} {
-		let hsla = RGBA2HSLA(this)
+		const hsla = RGBA2HSLA(this)
 		return hsla
 	}
 
@@ -224,7 +224,7 @@ export class Color {
 
 	/** Convert to `HSL(...)` format. */
 	toHSL() {
-		let hsla = RGBA2HSLA(this)
+		const hsla = RGBA2HSLA(this)
 		let {h, s, l} = hsla
 
 		h = clamp(Math.round(h * 60), 0, 360)
@@ -236,7 +236,7 @@ export class Color {
 
 	/** Convert to `HSLA(...)` format. */
 	toHSLA() {
-		let hsla = RGBA2HSLA(this)
+		const hsla = RGBA2HSLA(this)
 		let {h, s, l, a} = hsla
 
 		h = clamp(Math.round(h * 60), 0, 360)
@@ -254,7 +254,8 @@ export class Color {
 
 	/** Lighten color, `rate` betweens `0~1`. */
 	lighten(rate: number): Color {
-		let {r, g, b, a} = this
+		const {a} = this
+		let {r, g, b} = this
 
 		r += rate
 		g += rate
@@ -265,7 +266,7 @@ export class Color {
 
 	/** Invert current color and get a new color. */
 	invert() {
-		let {r, g, b, a} = this
+		const {r, g, b, a} = this
 		return new Color(1 - r, 1 - g, 1 - b, a)
 	}
 
@@ -319,12 +320,12 @@ export class Color {
 	 * @param inverseContrastRate specifies the rate which will multiple with `minimumLightContrast` when the color value exceed 0~1.
 	 */
 	improveContrast(compareColor: Color, minimumLightContrast: number = 0.15, inverseContrastRate: number = 0.5) {
-		let hsl = RGBA2HSLA(this)
-		let compareHSL = RGBA2HSLA(compareColor)
+		const hsl = RGBA2HSLA(this)
+		const compareHSL = RGBA2HSLA(compareColor)
 
 		// Calc the light diff in HSL color space.
-		let hslDiff = Math.abs(hsl.l - compareHSL.l)
-		let hslToFix = minimumLightContrast - hslDiff
+		const hslDiff = Math.abs(hsl.l - compareHSL.l)
+		const hslToFix = minimumLightContrast - hslDiff
 		
 		// Difference enough. 
 		if (hslToFix <= 0) {

--- a/server/src/utils/color/hsl.ts
+++ b/server/src/utils/color/hsl.ts
@@ -43,9 +43,9 @@ export function parseHSLA(str: string): HSLA | null {
 
 /** Convert HSLA to RGBA. */
 export function HSLA2RGBA(hsla: HSLA): RGBA {
-	let {h, s, l, a} = hsla
-	let maxOfRGB = l <= 0.5 ? l * (s + 1) : l + s - (l * s)
-	let minOfRGB = l * 2 - maxOfRGB
+	const {h, s, l, a} = hsla
+	const maxOfRGB = l <= 0.5 ? l * (s + 1) : l + s - (l * s)
+	const minOfRGB = l * 2 - maxOfRGB
 	
 	return {
 		r: hue2RGB(minOfRGB, maxOfRGB, (h + 2) % 6),
@@ -74,18 +74,18 @@ function hue2RGB(minOfRGB: number, maxOfRGB: number, hueDiff: number): number {
 
 /** Convert RGBA to HSLA. */
 export function RGBA2HSLA(rgba: RGBA): HSLA {
-	let {r, g, b, a} = rgba
-	let minOfRGB = Math.min(Math.min(r, g), b)
-	let maxOfRGB = Math.max(Math.max(r, g), b)
-	let l = (minOfRGB + maxOfRGB) / 2
+	const {r, g, b, a} = rgba
+	const minOfRGB = Math.min(Math.min(r, g), b)
+	const maxOfRGB = Math.max(Math.max(r, g), b)
+	const l = (minOfRGB + maxOfRGB) / 2
 
-	let s = minOfRGB == maxOfRGB
+	const s = minOfRGB == maxOfRGB
 		? 0
 		: (maxOfRGB - minOfRGB) / (l <= 0.5 ? minOfRGB + maxOfRGB : 2 - minOfRGB - maxOfRGB)
 
 	let h = 0
 
-	if (s == 0) {}
+	if (s == 0) { /* achromatic: hue stays 0 */ }
 	else if (r == maxOfRGB) {
 		h = ((g - b) / (maxOfRGB - minOfRGB) + 6) % 6
 	}

--- a/server/src/utils/fetch.ts
+++ b/server/src/utils/fetch.ts
@@ -5,10 +5,10 @@ import {promiseWithResolves} from './promise'
 
 
 export function fetchAsText(url: string): Promise<string> {
-	let protocol = URI.parse(url).scheme
-	let {promise, resolve, reject} = promiseWithResolves<string>()
+	const protocol = URI.parse(url).scheme
+	const {promise, resolve, reject} = promiseWithResolves<string>()
 
-	let req = (protocol === 'https' ? https : http).get(url, (res) => {
+	const req = (protocol === 'https' ? https : http).get(url, (res) => {
 		let data = ''
 		
 		res.on('data', (chunk) => {

--- a/server/src/utils/map.ts
+++ b/server/src/utils/map.ts
@@ -18,7 +18,7 @@ export class ListMap<K, V> {
 
 	/** Iterate all values. */
 	*values(): Iterable<V> {
-		for (let list of this.map.values()) {
+		for (const list of this.map.values()) {
 			yield* list
 		}
 	}
@@ -30,8 +30,8 @@ export class ListMap<K, V> {
 
 	/** Iterate each key and each associated value after flatted. */
 	*flatEntries(): Iterable<[K, V]> {
-		for (let [key, values] of this.map.entries()) {
-			for (let value of values) {
+		for (const [key, values] of this.map.entries()) {
+			for (const value of values) {
 				yield [key, value]
 			}
 		}
@@ -56,7 +56,7 @@ export class ListMap<K, V> {
 	valueCount(): number {
 		let count = 0
 
-		for (let values of this.map.values()) {
+		for (const values of this.map.values()) {
 			count += values.length
 		}
 
@@ -134,7 +134,7 @@ export class ListMap<K, V> {
 			this.map.set(k, values)
 		}
 
-		for (let v of vs) {
+		for (const v of vs) {
 			if (!values.includes(v)) {
 				values.push(v)
 			}
@@ -153,9 +153,9 @@ export class ListMap<K, V> {
 
 	/** Delete a key value pair. */
 	delete(k: K, v: V) {
-		let values = this.map.get(k)
+		const values = this.map.get(k)
 		if (values) {
-			let index = values.indexOf(v)
+			const index = values.indexOf(v)
 			if (index > -1) {
 				values.splice(index, 1)
 				
@@ -168,10 +168,10 @@ export class ListMap<K, V> {
 
 	/** Delete a key and several values. */
 	deleteSeveral(k: K, vs: Iterable<V>): void {
-		let values = this.map.get(k)
+		const values = this.map.get(k)
 		if (values) {
-			for (let v of vs) {
-				let index = values.indexOf(v)
+			for (const v of vs) {
+				const index = values.indexOf(v)
 				if (index > -1) {
 					values.splice(index, 1)
 				}
@@ -215,7 +215,7 @@ export class SetMap<K, V> {
 
 	/** Iterate all values. */
 	*values(): Iterable<V> {
-		for (let list of this.map.values()) {
+		for (const list of this.map.values()) {
 			yield* list
 		}
 	}
@@ -227,8 +227,8 @@ export class SetMap<K, V> {
 
 	/** Iterate each key and each associated value after flatted. */
 	*flatEntries(): Iterable<[K, V]> {
-		for (let [key, values] of this.map.entries()) {
-			for (let value of values) {
+		for (const [key, values] of this.map.entries()) {
+			for (const value of values) {
 				yield [key, value]
 			}
 		}
@@ -253,7 +253,7 @@ export class SetMap<K, V> {
 	valueCount(): number {
 		let count = 0
 
-		for (let values of this.map.values()) {
+		for (const values of this.map.values()) {
 			count += values.size
 		}
 
@@ -272,9 +272,9 @@ export class SetMap<K, V> {
 
 	/** Clone to get a new list map with same data. */
 	clone(): SetMap<K, V> {
-		let cloned = new SetMap<K, V>()
+		const cloned = new SetMap<K, V>()
 
-		for (let [key, set] of this.map.entries()) {
+		for (const [key, set] of this.map.entries()) {
 			cloned.map.set(key, new Set(set))
 		}
 
@@ -304,7 +304,7 @@ export class SetMap<K, V> {
 			this.map.set(k, values)
 		}
 		else {
-			for (let v of vs) {
+			for (const v of vs) {
 				values.add(v)
 			}
 		}
@@ -317,7 +317,7 @@ export class SetMap<K, V> {
 
 	/** Delete a key value pair. */
 	delete(k: K, v: V) {
-		let values = this.map.get(k)
+		const values = this.map.get(k)
 		if (values) {
 			values.delete(v)
 
@@ -329,9 +329,9 @@ export class SetMap<K, V> {
 
 	/** Delete a key and several values. */
 	deleteSeveral(k: K, vs: Iterable<V>): void {
-		let values = this.map.get(k)
+		const values = this.map.get(k)
 		if (values) {
-			for (let v of vs) {
+			for (const v of vs) {
 				values.delete(v)
 			}
 								
@@ -385,7 +385,7 @@ export class TwoWayListMap<L, R> {
 
 	/** Iterate associated right keys by left key. */
 	*rightValuesOf(l: L): Iterable<R> {
-		let rs = this.lm.get(l)
+		const rs = this.lm.get(l)
 		if (rs) {
 			yield* rs
 		} 
@@ -393,7 +393,7 @@ export class TwoWayListMap<L, R> {
 
 	/** Iterate associated left keys by right key. */
 	*leftValuesOf(r: R): Iterable<L> {
-		let ls = this.rm.get(r)
+		const ls = this.rm.get(r)
 		if (ls) {
 			yield* ls
 		}
@@ -475,9 +475,9 @@ export class TwoWayListMap<L, R> {
 
 	/** Delete by left key. */
 	deleteLeft(l: L) {
-		let rs = this.getByLeft(l)
+		const rs = this.getByLeft(l)
 		if (rs) {
-			for (let r of rs) {
+			for (const r of rs) {
 				this.rm.delete(r, l)
 			}
 
@@ -487,9 +487,9 @@ export class TwoWayListMap<L, R> {
 
 	/** Delete by right key. */
 	deleteRight(r: R) {
-		let ls = this.getByRight(r)
+		const ls = this.getByRight(r)
 		if (ls) {
-			for (let l of ls) {
+			for (const l of ls) {
 				this.lm.delete(l, r)
 			}
 
@@ -499,23 +499,23 @@ export class TwoWayListMap<L, R> {
 
 	/** Replace left and all it's associated right keys. */
 	replaceLeft(l: L, rs: R[]) {
-		let oldRs = this.lm.get(l)
+		const oldRs = this.lm.get(l)
 
 		if (oldRs) {
-			for (let r of rs) {
+			for (const r of rs) {
 				if (!oldRs.includes(r)) {
 					this.rm.add(r, l)
 				}
 			}
 
-			for (let r of oldRs) {
+			for (const r of oldRs) {
 				if (!rs.includes(r)) {
 					this.rm.delete(r, l)
 				}
 			}
 		}
 		else {
-			for (let r of rs) {
+			for (const r of rs) {
 				this.rm.add(r, l)
 			}
 		}
@@ -532,23 +532,23 @@ export class TwoWayListMap<L, R> {
 
 	/** Replace right and all it's associated left keys. */
 	replaceRight(r: R, ls: L[]) {
-		let oldLs = this.rm.get(r)
+		const oldLs = this.rm.get(r)
 
 		if (oldLs) {
-			for (let l of ls) {
+			for (const l of ls) {
 				if (!oldLs.includes(l)) {
 					this.lm.add(l, r)
 				}
 			}
 
-			for (let l of oldLs) {
+			for (const l of oldLs) {
 				if (!ls.includes(l)) {
 					this.lm.delete(l, r)
 				}
 			}
 		}
 		else {
-			for (let l of ls) {
+			for (const l of ls) {
 				this.lm.add(l, r)
 			}
 		}

--- a/server/src/utils/number.ts
+++ b/server/src/utils/number.ts
@@ -21,14 +21,12 @@ export function toDecimal(number: number, decimalCount: number): number {
 		return 0
 	}
 
-	Number.prototype.toFixed
-
 	if (decimalCount > 0) {
-		let n = Math.pow(10, decimalCount)
+		const n = Math.pow(10, decimalCount)
 		return Math.round(number * n) / n
 	}
 	else {
-		let n = Math.pow(10, -decimalCount)
+		const n = Math.pow(10, -decimalCount)
 		return Math.round(number / n) * n
 	}
 }

--- a/server/src/utils/path.ts
+++ b/server/src/utils/path.ts
@@ -3,9 +3,9 @@ import * as path from 'path'
 
 /** Get longest common subsequence length of two paths. */
 export function getLongestCommonSubsequenceLength(a: string, b: string): number {
-	let m = a.length
-	let n = b.length
-	let len = Math.min(m, n)
+	const m = a.length
+	const n = b.length
+	const len = Math.min(m, n)
 
 	for (let i = 0; i < len; i++) {
 		if (a[i] !== b[i]) {

--- a/server/src/utils/promise.ts
+++ b/server/src/utils/promise.ts
@@ -2,15 +2,15 @@
 export function promiseWithResolves<T = void>(): {
 	promise: Promise<T>,
 	resolve: (value: T | PromiseLike<T>) => void,
-	reject: (err?: any) => void
+	reject: (reason?: unknown) => void
 } {
 	let resolve: (value: T | PromiseLike<T>) => void
-	let reject: (err: any) => void
+	let reject: (reason?: unknown) => void
 
-	let promise = new Promise((res, rej) => {
-		resolve = res as (value: T | PromiseLike<T>) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
 		reject = rej
-	}) as Promise<T>
+	})
 
 	return {
 		promise,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,8 +1,11 @@
 {
 	"compilerOptions": {
 		"target": "esnext",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"moduleDetection": "legacy",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"sourceMap": true,
 		"outDir": "out",
 		"rootDir": "src",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -17,8 +17,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"noImplicitAny": true,
 		"noImplicitThis": true,
-		"composite": true,
-		"ignoreDeprecations": "6.0"
+		"composite": true
 	},
 	"include": ["src"],
 	"exclude": [

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -19,7 +19,10 @@
 		"noImplicitThis": true,
 		"composite": true
 	},
-	"include": ["src"],
+	"include": [
+		"src",
+		"../types/**/*.d.ts"
+	],
 	"exclude": [
 		"node_modules", 
 		".vscode-test"

--- a/types/css-navigation.d.ts
+++ b/types/css-navigation.d.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- ambient global type, consumed across the client and server
 interface InitializationOptions {
 	workspaceFolderPath: string
 	configuration: Configuration


### PR DESCRIPTION
## Summary

This fixes the CSS Navigation startup failure reported in issue #136 by moving the extension to the current VS Code language client/server stack and making the test/build pipeline reproducible from a clean checkout.

## What changed

- Upgraded `vscode-languageclient` and `vscode-languageserver` to v10-compatible packages, including the required Node16 module resolution changes.
- Replaced the deprecated `vscode` test package with `@vscode/test-electron` and added a cross-platform GitHub Actions matrix for VS Code 1.91.0 and stable.
- Fixed VSIX packaging so the runtime dependencies required by `vscode-languageclient@10` are included.
- Added type-aware ESLint checks and cleaned up the findings without changing runtime behavior.
- Moved shared configuration types out of generated `out/` files so lint works from a clean checkout before build output exists.
- Restored the e2e fixture module used by import-resolution tests and made the VS Code test runner more robust on macOS and Windows CI.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`
- `npm run e2e-test`
- `VSCODE_VERSION=1.91.0 npm run e2e-test`
- GitHub Actions Test suite on the fork: https://github.com/illusionfield/vscode-css-navigation/actions/runs/27019761065

Fixes #136.
